### PR TITLE
Fixes #129: Implements sending events to the notification center.

### DIFF
--- a/Mac/Resources/en.lproj/PreferencesWindow.xib
+++ b/Mac/Resources/en.lproj/PreferencesWindow.xib
@@ -1,12920 +1,2672 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<archive type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="8.00">
-	<data>
-		<int key="IBDocument.SystemTarget">1070</int>
-		<string key="IBDocument.SystemVersion">12E55</string>
-		<string key="IBDocument.InterfaceBuilderVersion">3084</string>
-		<string key="IBDocument.AppKitVersion">1187.39</string>
-		<string key="IBDocument.HIToolboxVersion">626.00</string>
-		<object class="NSMutableDictionary" key="IBDocument.PluginVersions">
-			<string key="NS.key.0">com.apple.InterfaceBuilder.CocoaPlugin</string>
-			<string key="NS.object.0">3084</string>
-		</object>
-		<array key="IBDocument.IntegratedClassDependencies">
-			<string>NSBox</string>
-			<string>NSButton</string>
-			<string>NSButtonCell</string>
-			<string>NSColorWell</string>
-			<string>NSCustomObject</string>
-			<string>NSMenu</string>
-			<string>NSMenuItem</string>
-			<string>NSOutlineView</string>
-			<string>NSPopUpButton</string>
-			<string>NSPopUpButtonCell</string>
-			<string>NSScrollView</string>
-			<string>NSScroller</string>
-			<string>NSSlider</string>
-			<string>NSSliderCell</string>
-			<string>NSStepper</string>
-			<string>NSStepperCell</string>
-			<string>NSTabView</string>
-			<string>NSTabViewItem</string>
-			<string>NSTableColumn</string>
-			<string>NSTableHeaderView</string>
-			<string>NSTableView</string>
-			<string>NSTextField</string>
-			<string>NSTextFieldCell</string>
-			<string>NSView</string>
-			<string>NSWindowTemplate</string>
-		</array>
-		<array key="IBDocument.PluginDependencies">
-			<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-		</array>
-		<object class="NSMutableDictionary" key="IBDocument.Metadata">
-			<string key="NS.key.0">PluginDependencyRecalculationVersion</string>
-			<integer value="1" key="NS.object.0"/>
-		</object>
-		<array class="NSMutableArray" key="IBDocument.RootObjects" id="156144608">
-			<object class="NSCustomObject" id="11157371">
-				<string key="NSClassName">NSWindowController</string>
-			</object>
-			<object class="NSCustomObject" id="402593865">
-				<string key="NSClassName">FirstResponder</string>
-			</object>
-			<object class="NSCustomObject" id="676093597">
-				<string key="NSClassName">NSApplication</string>
-			</object>
-			<object class="NSWindowTemplate" id="120409092">
-				<int key="NSWindowStyleMask">7</int>
-				<int key="NSWindowBacking">2</int>
-				<string key="NSWindowRect">{{466, 125}, {640, 497}}</string>
-				<int key="NSWTFlags">1886912512</int>
-				<string key="NSWindowTitle">XChat: Preferences</string>
-				<string key="NSWindowClass">PreferencesWindow</string>
-				<object class="NSMutableString" key="NSViewClass">
-					<characters key="NS.bytes">View</characters>
-				</object>
-				<nil key="NSUserInterfaceItemIdentifier"/>
-				<string key="NSWindowContentMaxSize">{640, 497}</string>
-				<string key="NSWindowContentMinSize">{640, 497}</string>
-				<object class="NSView" key="NSWindowView" id="812753686">
-					<reference key="NSNextResponder"/>
-					<int key="NSvFlags">274</int>
-					<array class="NSMutableArray" key="NSSubviews">
-						<object class="NSButton" id="247430523">
-							<reference key="NSNextResponder" ref="812753686"/>
-							<int key="NSvFlags">289</int>
-							<string key="NSFrame">{{542, 12}, {84, 32}}</string>
-							<reference key="NSSuperview" ref="812753686"/>
-							<reference key="NSWindow"/>
-							<bool key="NSEnabled">YES</bool>
-							<object class="NSButtonCell" key="NSCell" id="375248671">
-								<int key="NSCellFlags">67108864</int>
-								<int key="NSCellFlags2">134217728</int>
-								<string key="NSContents">OK</string>
-								<object class="NSFont" key="NSSupport" id="218849127">
-									<string key="NSName">LucidaGrande</string>
-									<double key="NSSize">13</double>
-									<int key="NSfFlags">1044</int>
-								</object>
-								<reference key="NSControlView" ref="247430523"/>
-								<int key="NSButtonFlags">-2038284288</int>
-								<int key="NSButtonFlags2">1</int>
-								<reference key="NSAlternateImage" ref="218849127"/>
-								<string key="NSAlternateContents"/>
-								<string type="base64-UTF8" key="NSKeyEquivalent">DQ</string>
-								<int key="NSPeriodicDelay">200</int>
-								<int key="NSPeriodicInterval">25</int>
-							</object>
-							<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-						</object>
-						<object class="NSButton" id="662298341">
-							<reference key="NSNextResponder" ref="812753686"/>
-							<int key="NSvFlags">289</int>
-							<string key="NSFrame">{{458, 12}, {84, 32}}</string>
-							<reference key="NSSuperview" ref="812753686"/>
-							<reference key="NSWindow"/>
-							<reference key="NSNextKeyView" ref="247430523"/>
-							<bool key="NSEnabled">YES</bool>
-							<object class="NSButtonCell" key="NSCell" id="295232266">
-								<int key="NSCellFlags">67108864</int>
-								<int key="NSCellFlags2">137887744</int>
-								<string key="NSContents">Cancel</string>
-								<reference key="NSSupport" ref="218849127"/>
-								<reference key="NSControlView" ref="662298341"/>
-								<int key="NSButtonFlags">-2038284288</int>
-								<int key="NSButtonFlags2">1</int>
-								<reference key="NSAlternateImage" ref="218849127"/>
-								<string key="NSAlternateContents"/>
-								<string type="base64-UTF8" key="NSKeyEquivalent">Gw</string>
-								<int key="NSPeriodicDelay">200</int>
-								<int key="NSPeriodicInterval">25</int>
-							</object>
-							<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-						</object>
-						<object class="NSButton" id="26097905">
-							<reference key="NSNextResponder" ref="812753686"/>
-							<int key="NSvFlags">289</int>
-							<string key="NSFrame">{{374, 12}, {84, 32}}</string>
-							<reference key="NSSuperview" ref="812753686"/>
-							<reference key="NSWindow"/>
-							<reference key="NSNextKeyView" ref="662298341"/>
-							<bool key="NSEnabled">YES</bool>
-							<object class="NSButtonCell" key="NSCell" id="737667532">
-								<int key="NSCellFlags">67108864</int>
-								<int key="NSCellFlags2">137887744</int>
-								<string key="NSContents">Apply</string>
-								<reference key="NSSupport" ref="218849127"/>
-								<reference key="NSControlView" ref="26097905"/>
-								<int key="NSButtonFlags">-2038284288</int>
-								<int key="NSButtonFlags2">1</int>
-								<reference key="NSAlternateImage" ref="218849127"/>
-								<string key="NSAlternateContents"/>
-								<object class="NSMutableString" key="NSKeyEquivalent">
-									<characters key="NS.bytes"/>
-								</object>
-								<int key="NSPeriodicDelay">200</int>
-								<int key="NSPeriodicInterval">25</int>
-							</object>
-							<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-						</object>
-						<object class="NSScrollView" id="977242452">
-							<reference key="NSNextResponder" ref="812753686"/>
-							<int key="NSvFlags">276</int>
-							<array class="NSMutableArray" key="NSSubviews">
-								<object class="NSClipView" id="936460462">
-									<reference key="NSNextResponder" ref="977242452"/>
-									<int key="NSvFlags">2304</int>
-									<array class="NSMutableArray" key="NSSubviews">
-										<object class="NSOutlineView" id="532939042">
-											<reference key="NSNextResponder" ref="936460462"/>
-											<int key="NSvFlags">256</int>
-											<string key="NSFrameSize">{136, 415}</string>
-											<reference key="NSSuperview" ref="936460462"/>
-											<reference key="NSWindow"/>
-											<reference key="NSNextKeyView" ref="424564569"/>
-											<bool key="NSEnabled">YES</bool>
-											<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-											<bool key="NSControlAllowsExpansionToolTips">YES</bool>
-											<object class="_NSCornerView" key="NSCornerView">
-												<nil key="NSNextResponder"/>
-												<int key="NSvFlags">256</int>
-												<string key="NSFrame">{{126, 0}, {12, 17}}</string>
-											</object>
-											<array class="NSMutableArray" key="NSTableColumns">
-												<object class="NSTableColumn" id="833634636">
-													<double key="NSWidth">121.95999908447266</double>
-													<double key="NSMinWidth">16</double>
-													<double key="NSMaxWidth">1000</double>
-													<object class="NSTableHeaderCell" key="NSHeaderCell">
-														<int key="NSCellFlags">75497536</int>
-														<int key="NSCellFlags2">2048</int>
-														<string key="NSContents">Categories</string>
-														<object class="NSFont" key="NSSupport" id="26">
-															<string key="NSName">LucidaGrande</string>
-															<double key="NSSize">11</double>
-															<int key="NSfFlags">3100</int>
-														</object>
-														<object class="NSColor" key="NSBackgroundColor" id="121655387">
-															<int key="NSColorSpace">6</int>
-															<string key="NSCatalogName">System</string>
-															<string key="NSColorName">headerColor</string>
-															<object class="NSColor" key="NSColor" id="300919276">
-																<int key="NSColorSpace">3</int>
-																<bytes key="NSWhite">MQA</bytes>
-															</object>
-														</object>
-														<object class="NSColor" key="NSTextColor" id="106531208">
-															<int key="NSColorSpace">6</int>
-															<string key="NSCatalogName">System</string>
-															<string key="NSColorName">headerTextColor</string>
-															<object class="NSColor" key="NSColor" id="1012182062">
-																<int key="NSColorSpace">3</int>
-																<bytes key="NSWhite">MAA</bytes>
-															</object>
-														</object>
-													</object>
-													<object class="NSTextFieldCell" key="NSDataCell" id="208271096">
-														<int key="NSCellFlags">338690112</int>
-														<int key="NSCellFlags2">1024</int>
-														<object class="NSFont" key="NSSupport">
-															<string key="NSName">LucidaGrande</string>
-															<double key="NSSize">12</double>
-															<int key="NSfFlags">16</int>
-														</object>
-														<reference key="NSControlView" ref="532939042"/>
-														<bool key="NSDrawsBackground">YES</bool>
-														<object class="NSColor" key="NSBackgroundColor" id="106922994">
-															<int key="NSColorSpace">6</int>
-															<string key="NSCatalogName">System</string>
-															<string key="NSColorName">controlBackgroundColor</string>
-															<object class="NSColor" key="NSColor" id="630532811">
-																<int key="NSColorSpace">3</int>
-																<bytes key="NSWhite">MC42NjY2NjY2NjY3AA</bytes>
-															</object>
-														</object>
-														<object class="NSColor" key="NSTextColor" id="725989266">
-															<int key="NSColorSpace">6</int>
-															<string key="NSCatalogName">System</string>
-															<string key="NSColorName">controlTextColor</string>
-															<reference key="NSColor" ref="1012182062"/>
-														</object>
-													</object>
-													<reference key="NSTableView" ref="532939042"/>
-												</object>
-											</array>
-											<double key="NSIntercellSpacingWidth">3</double>
-											<double key="NSIntercellSpacingHeight">2</double>
-											<reference key="NSBackgroundColor" ref="300919276"/>
-											<object class="NSColor" key="NSGridColor" id="88460656">
-												<int key="NSColorSpace">6</int>
-												<string key="NSCatalogName">System</string>
-												<string key="NSColorName">gridColor</string>
-												<object class="NSColor" key="NSColor">
-													<int key="NSColorSpace">3</int>
-													<bytes key="NSWhite">MC41AA</bytes>
-												</object>
-											</object>
-											<double key="NSRowHeight">17</double>
-											<int key="NSTvFlags">35684352</int>
-											<reference key="NSDelegate"/>
-											<reference key="NSDataSource"/>
-											<int key="NSColumnAutoresizingStyle">1</int>
-											<int key="NSDraggingSourceMaskForLocal">15</int>
-											<int key="NSDraggingSourceMaskForNonLocal">0</int>
-											<bool key="NSAllowsTypeSelect">YES</bool>
-											<int key="NSTableViewDraggingDestinationStyle">0</int>
-											<int key="NSTableViewGroupRowStyle">1</int>
-										</object>
-									</array>
-									<string key="NSFrame">{{1, 1}, {136, 415}}</string>
-									<reference key="NSSuperview" ref="977242452"/>
-									<reference key="NSWindow"/>
-									<reference key="NSNextKeyView" ref="532939042"/>
-									<reference key="NSDocView" ref="532939042"/>
-									<reference key="NSBGColor" ref="106922994"/>
-									<int key="NScvFlags">4</int>
-								</object>
-								<object class="NSScroller" id="878483055">
-									<reference key="NSNextResponder" ref="977242452"/>
-									<int key="NSvFlags">256</int>
-									<string key="NSFrame">{{123, 1}, {14, 415}}</string>
-									<reference key="NSSuperview" ref="977242452"/>
-									<reference key="NSWindow"/>
-									<reference key="NSNextKeyView" ref="543522030"/>
-									<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-									<int key="NSsFlags">256</int>
-									<reference key="NSTarget" ref="977242452"/>
-									<string key="NSAction">_doScroller:</string>
-									<double key="NSPercent">0.99759615384615385</double>
-								</object>
-								<object class="NSScroller" id="424564569">
-									<reference key="NSNextResponder" ref="977242452"/>
-									<int key="NSvFlags">-2147483392</int>
-									<string key="NSFrame">{{-100, -100}, {125, 11}}</string>
-									<reference key="NSSuperview" ref="977242452"/>
-									<reference key="NSWindow"/>
-									<reference key="NSNextKeyView" ref="936460462"/>
-									<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-									<int key="NSsFlags">257</int>
-									<reference key="NSTarget" ref="977242452"/>
-									<string key="NSAction">_doScroller:</string>
-									<double key="NSCurValue">0.024</double>
-									<double key="NSPercent">0.89285707473754883</double>
-								</object>
-							</array>
-							<string key="NSFrame">{{20, 60}, {138, 417}}</string>
-							<reference key="NSSuperview" ref="812753686"/>
-							<reference key="NSWindow"/>
-							<reference key="NSNextKeyView" ref="936460462"/>
-							<int key="NSsFlags">133138</int>
-							<reference key="NSVScroller" ref="878483055"/>
-							<reference key="NSHScroller" ref="424564569"/>
-							<reference key="NSContentView" ref="936460462"/>
-							<bytes key="NSScrollAmts">QSAAAEEgAABBmAAAQZgAAA</bytes>
-							<double key="NSMinMagnification">0.25</double>
-							<double key="NSMaxMagnification">4</double>
-							<double key="NSMagnification">1</double>
-						</object>
-						<object class="NSBox" id="543522030">
-							<reference key="NSNextResponder" ref="812753686"/>
-							<int key="NSvFlags">274</int>
-							<array class="NSMutableArray" key="NSSubviews">
-								<object class="NSView" id="27621534">
-									<reference key="NSNextResponder" ref="543522030"/>
-									<int key="NSvFlags">274</int>
-									<array class="NSMutableArray" key="NSSubviews">
-										<object class="NSTabView" id="1053574686">
-											<reference key="NSNextResponder" ref="27621534"/>
-											<int key="NSvFlags">274</int>
-											<string key="NSFrame">{{4, 2}, {449, 406}}</string>
-											<reference key="NSSuperview" ref="27621534"/>
-											<reference key="NSWindow"/>
-											<reference key="NSNextKeyView" ref="715816214"/>
-											<array class="NSMutableArray" key="NSTabViewItems">
-												<object class="NSTabViewItem" id="815118087">
-													<object class="NSView" key="NSView" id="715816214">
-														<reference key="NSNextResponder" ref="1053574686"/>
-														<int key="NSvFlags">274</int>
-														<array class="NSMutableArray" key="NSSubviews">
-															<object class="NSTextField" id="117700411">
-																<reference key="NSNextResponder" ref="715816214"/>
-																<int key="NSvFlags">266</int>
-																<string key="NSFrame">{{161, 354}, {179, 19}}</string>
-																<reference key="NSSuperview" ref="715816214"/>
-																<reference key="NSWindow"/>
-																<reference key="NSNextKeyView" ref="1007387692"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSTextFieldCell" key="NSCell" id="939822168">
-																	<int key="NSCellFlags">-2073034687</int>
-																	<int key="NSCellFlags2">4195328</int>
-																	<string key="NSContents"/>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="117700411"/>
-																	<bool key="NSDrawsBackground">YES</bool>
-																	<object class="NSColor" key="NSBackgroundColor" id="265355499">
-																		<int key="NSColorSpace">6</int>
-																		<string key="NSCatalogName">System</string>
-																		<string key="NSColorName">textBackgroundColor</string>
-																		<reference key="NSColor" ref="300919276"/>
-																	</object>
-																	<object class="NSColor" key="NSTextColor" id="328927124">
-																		<int key="NSColorSpace">6</int>
-																		<string key="NSCatalogName">System</string>
-																		<string key="NSColorName">textColor</string>
-																		<reference key="NSColor" ref="1012182062"/>
-																	</object>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSTextField" id="16204397">
-																<reference key="NSNextResponder" ref="715816214"/>
-																<int key="NSvFlags">266</int>
-																<string key="NSFrame">{{161, 330}, {50, 19}}</string>
-																<reference key="NSSuperview" ref="715816214"/>
-																<reference key="NSWindow"/>
-																<reference key="NSNextKeyView" ref="228398657"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSTextFieldCell" key="NSCell" id="505560439">
-																	<int key="NSCellFlags">-1804599231</int>
-																	<int key="NSCellFlags2">4195328</int>
-																	<string key="NSContents"/>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="16204397"/>
-																	<bool key="NSDrawsBackground">YES</bool>
-																	<reference key="NSBackgroundColor" ref="265355499"/>
-																	<reference key="NSTextColor" ref="328927124"/>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSTextField" id="17670746">
-																<reference key="NSNextResponder" ref="715816214"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{32, 356}, {124, 14}}</string>
-																<reference key="NSSuperview" ref="715816214"/>
-																<reference key="NSWindow"/>
-																<reference key="NSNextKeyView" ref="117700411"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSTextFieldCell" key="NSCell" id="80801900">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">71303168</int>
-																	<string key="NSContents">Font:</string>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="17670746"/>
-																	<object class="NSColor" key="NSBackgroundColor" id="1007130360">
-																		<int key="NSColorSpace">6</int>
-																		<string key="NSCatalogName">System</string>
-																		<string key="NSColorName">controlColor</string>
-																		<reference key="NSColor" ref="630532811"/>
-																	</object>
-																	<reference key="NSTextColor" ref="725989266"/>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSTextField" id="781764471">
-																<reference key="NSNextResponder" ref="715816214"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{32, 329}, {124, 17}}</string>
-																<reference key="NSSuperview" ref="715816214"/>
-																<reference key="NSWindow"/>
-																<reference key="NSNextKeyView" ref="16204397"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSTextFieldCell" key="NSCell" id="970892027">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">71303168</int>
-																	<string key="NSContents">Line height:</string>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="781764471"/>
-																	<reference key="NSBackgroundColor" ref="1007130360"/>
-																	<reference key="NSTextColor" ref="725989266"/>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSTextField" id="228398657">
-																<reference key="NSNextResponder" ref="715816214"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{209, 331}, {124, 17}}</string>
-																<reference key="NSSuperview" ref="715816214"/>
-																<reference key="NSWindow"/>
-																<reference key="NSNextKeyView" ref="312647408"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSTextFieldCell" key="NSCell" id="919012485">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">4194304</int>
-																	<string key="NSContents">%</string>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="228398657"/>
-																	<reference key="NSBackgroundColor" ref="1007130360"/>
-																	<reference key="NSTextColor" ref="725989266"/>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSTextField" id="15380591">
-																<reference key="NSNextResponder" ref="715816214"/>
-																<int key="NSvFlags">266</int>
-																<string key="NSFrame">{{161, 89}, {220, 19}}</string>
-																<reference key="NSSuperview" ref="715816214"/>
-																<reference key="NSWindow"/>
-																<reference key="NSNextKeyView" ref="1053574686"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSTextFieldCell" key="NSCell" id="280211799">
-																	<int key="NSCellFlags">-1804599231</int>
-																	<int key="NSCellFlags2">4195328</int>
-																	<string key="NSContents"/>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="15380591"/>
-																	<bool key="NSDrawsBackground">YES</bool>
-																	<reference key="NSBackgroundColor" ref="265355499"/>
-																	<reference key="NSTextColor" ref="328927124"/>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSTextField" id="713131109">
-																<reference key="NSNextResponder" ref="715816214"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{20, 92}, {136, 14}}</string>
-																<reference key="NSSuperview" ref="715816214"/>
-																<reference key="NSWindow"/>
-																<reference key="NSNextKeyView" ref="15380591"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSTextFieldCell" key="NSCell" id="429483781">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">71303168</int>
-																	<string key="NSContents">Time stamp format:</string>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="713131109"/>
-																	<reference key="NSBackgroundColor" ref="1007130360"/>
-																	<reference key="NSTextColor" ref="725989266"/>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSButton" id="1007387692">
-																<reference key="NSNextResponder" ref="715816214"/>
-																<int key="NSvFlags">265</int>
-																<string key="NSFrame">{{343, 348}, {91, 28}}</string>
-																<reference key="NSSuperview" ref="715816214"/>
-																<reference key="NSWindow"/>
-																<reference key="NSNextKeyView" ref="781764471"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSButtonCell" key="NSCell" id="17521243">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">134348800</int>
-																	<string key="NSContents">Browse...</string>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="1007387692"/>
-																	<int key="NSButtonFlags">-2038284288</int>
-																	<int key="NSButtonFlags2">1</int>
-																	<reference key="NSAlternateImage" ref="26"/>
-																	<string key="NSAlternateContents"/>
-																	<object class="NSMutableString" key="NSKeyEquivalent">
-																		<characters key="NS.bytes"/>
-																	</object>
-																	<int key="NSPeriodicDelay">200</int>
-																	<int key="NSPeriodicInterval">25</int>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSTextField" id="195567578">
-																<reference key="NSNextResponder" ref="715816214"/>
-																<int key="NSvFlags">266</int>
-																<string key="NSFrame">{{161, 304}, {159, 19}}</string>
-																<reference key="NSSuperview" ref="715816214"/>
-																<reference key="NSWindow"/>
-																<reference key="NSNextKeyView" ref="311130897"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSTextFieldCell" key="NSCell" id="630544053">
-																	<int key="NSCellFlags">-2073034687</int>
-																	<int key="NSCellFlags2">4195328</int>
-																	<string key="NSContents"/>
-																	<reference key="NSSupport" ref="26"/>
-																	<string key="NSPlaceholderString">(No Image)</string>
-																	<reference key="NSControlView" ref="195567578"/>
-																	<bool key="NSDrawsBackground">YES</bool>
-																	<reference key="NSBackgroundColor" ref="265355499"/>
-																	<reference key="NSTextColor" ref="328927124"/>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSTextField" id="312647408">
-																<reference key="NSNextResponder" ref="715816214"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{32, 303}, {124, 17}}</string>
-																<reference key="NSSuperview" ref="715816214"/>
-																<reference key="NSWindow"/>
-																<reference key="NSNextKeyView" ref="195567578"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSTextFieldCell" key="NSCell" id="41031450">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">71303168</int>
-																	<string key="NSContents">Background image:</string>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="312647408"/>
-																	<reference key="NSBackgroundColor" ref="1007130360"/>
-																	<reference key="NSTextColor" ref="725989266"/>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSButton" id="619505271">
-																<reference key="NSNextResponder" ref="715816214"/>
-																<int key="NSvFlags">265</int>
-																<string key="NSFrame">{{343, 298}, {91, 28}}</string>
-																<reference key="NSSuperview" ref="715816214"/>
-																<reference key="NSWindow"/>
-																<reference key="NSNextKeyView" ref="1017938941"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSButtonCell" key="NSCell" id="228489341">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">134348800</int>
-																	<string key="NSContents">Browse...</string>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="619505271"/>
-																	<int key="NSButtonFlags">-2038284288</int>
-																	<int key="NSButtonFlags2">1</int>
-																	<reference key="NSAlternateImage" ref="26"/>
-																	<string key="NSAlternateContents"/>
-																	<object class="NSMutableString" key="NSKeyEquivalent">
-																		<characters key="NS.bytes"/>
-																	</object>
-																	<int key="NSPeriodicDelay">200</int>
-																	<int key="NSPeriodicInterval">25</int>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSButton" id="311130897">
-																<reference key="NSNextResponder" ref="715816214"/>
-																<int key="NSvFlags">265</int>
-																<string key="NSFrame">{{320, 303}, {21, 21}}</string>
-																<reference key="NSSuperview" ref="715816214"/>
-																<reference key="NSWindow"/>
-																<reference key="NSNextKeyView" ref="619505271"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSButtonCell" key="NSCell" id="707145847">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">134348800</int>
-																	<string key="NSContents"/>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="311130897"/>
-																	<int key="NSButtonFlags">-2033434624</int>
-																	<int key="NSButtonFlags2">34</int>
-																	<object class="NSCustomResource" key="NSNormalImage">
-																		<string key="NSClassName">NSImage</string>
-																		<string key="NSResourceName">NSStopProgressTemplate</string>
-																	</object>
-																	<string key="NSAlternateContents"/>
-																	<object class="NSMutableString" key="NSKeyEquivalent">
-																		<characters key="NS.bytes"/>
-																	</object>
-																	<int key="NSPeriodicDelay">200</int>
-																	<int key="NSPeriodicInterval">25</int>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSButton" id="232859697">
-																<reference key="NSNextResponder" ref="715816214"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{231, 279}, {200, 19}}</string>
-																<reference key="NSSuperview" ref="715816214"/>
-																<reference key="NSWindow"/>
-																<reference key="NSNextKeyView" ref="492037363"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSButtonCell" key="NSCell" id="90870237">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">131072</int>
-																	<string key="NSContents">Strip scrollback color</string>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="232859697"/>
-																	<int key="NSButtonFlags">1211912448</int>
-																	<int key="NSButtonFlags2">2</int>
-																	<object class="NSCustomResource" key="NSNormalImage" id="557231633">
-																		<string key="NSClassName">NSImage</string>
-																		<string key="NSResourceName">NSSwitch</string>
-																	</object>
-																	<object class="NSButtonImageSource" key="NSAlternateImage" id="152492997">
-																		<string key="NSImageName">NSSwitch</string>
-																	</object>
-																	<string key="NSAlternateContents"/>
-																	<string key="NSKeyEquivalent"/>
-																	<int key="NSPeriodicDelay">200</int>
-																	<int key="NSPeriodicInterval">25</int>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSButton" id="452140972">
-																<reference key="NSNextResponder" ref="715816214"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{29, 232}, {198, 19}}</string>
-																<reference key="NSSuperview" ref="715816214"/>
-																<reference key="NSWindow"/>
-																<reference key="NSNextKeyView" ref="180817061"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSButtonCell" key="NSCell" id="853966779">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">131072</int>
-																	<string key="NSContents">Show separator</string>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="452140972"/>
-																	<int key="NSButtonFlags">1211912448</int>
-																	<int key="NSButtonFlags2">2</int>
-																	<reference key="NSNormalImage" ref="557231633"/>
-																	<reference key="NSAlternateImage" ref="152492997"/>
-																	<string key="NSAlternateContents"/>
-																	<string key="NSKeyEquivalent"/>
-																	<int key="NSPeriodicDelay">200</int>
-																	<int key="NSPeriodicInterval">25</int>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSButton" id="180817061">
-																<reference key="NSNextResponder" ref="715816214"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{231, 232}, {200, 19}}</string>
-																<reference key="NSSuperview" ref="715816214"/>
-																<reference key="NSWindow"/>
-																<reference key="NSNextKeyView" ref="539390510"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSButtonCell" key="NSCell" id="982821600">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">131072</int>
-																	<string key="NSContents">Strip mIRC color</string>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="180817061"/>
-																	<int key="NSButtonFlags">1211912448</int>
-																	<int key="NSButtonFlags2">2</int>
-																	<reference key="NSNormalImage" ref="557231633"/>
-																	<reference key="NSAlternateImage" ref="152492997"/>
-																	<string key="NSAlternateContents"/>
-																	<string key="NSKeyEquivalent"/>
-																	<int key="NSPeriodicDelay">200</int>
-																	<int key="NSPeriodicInterval">25</int>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSButton" id="40697488">
-																<reference key="NSNextResponder" ref="715816214"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{29, 114}, {231, 19}}</string>
-																<reference key="NSSuperview" ref="715816214"/>
-																<reference key="NSWindow"/>
-																<reference key="NSNextKeyView" ref="713131109"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSButtonCell" key="NSCell" id="470434084">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">131072</int>
-																	<string key="NSContents">Enable time stamps</string>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="40697488"/>
-																	<int key="NSButtonFlags">1211912448</int>
-																	<int key="NSButtonFlags2">2</int>
-																	<reference key="NSNormalImage" ref="557231633"/>
-																	<reference key="NSAlternateImage" ref="152492997"/>
-																	<string key="NSAlternateContents"/>
-																	<string key="NSKeyEquivalent"/>
-																	<int key="NSPeriodicDelay">200</int>
-																	<int key="NSPeriodicInterval">25</int>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSButton" id="206913966">
-																<reference key="NSNextResponder" ref="715816214"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{231, 252}, {200, 19}}</string>
-																<reference key="NSSuperview" ref="715816214"/>
-																<reference key="NSWindow"/>
-																<reference key="NSNextKeyView" ref="452140972"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSButtonCell" key="NSCell" id="377830616">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">131072</int>
-																	<string key="NSContents">Indent nick names</string>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="206913966"/>
-																	<int key="NSButtonFlags">1211912448</int>
-																	<int key="NSButtonFlags2">2</int>
-																	<reference key="NSNormalImage" ref="557231633"/>
-																	<reference key="NSAlternateImage" ref="152492997"/>
-																	<string key="NSAlternateContents"/>
-																	<string key="NSKeyEquivalent"/>
-																	<int key="NSPeriodicDelay">200</int>
-																	<int key="NSPeriodicInterval">25</int>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSButton" id="492037363">
-																<reference key="NSNextResponder" ref="715816214"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{29, 252}, {198, 19}}</string>
-																<reference key="NSSuperview" ref="715816214"/>
-																<reference key="NSWindow"/>
-																<reference key="NSNextKeyView" ref="206913966"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSButtonCell" key="NSCell" id="1069924385">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">131072</int>
-																	<string key="NSContents">Colored nick names</string>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="492037363"/>
-																	<int key="NSButtonFlags">1211912448</int>
-																	<int key="NSButtonFlags2">2</int>
-																	<reference key="NSNormalImage" ref="557231633"/>
-																	<reference key="NSAlternateImage" ref="152492997"/>
-																	<string key="NSAlternateContents"/>
-																	<string key="NSKeyEquivalent"/>
-																	<int key="NSPeriodicDelay">200</int>
-																	<int key="NSPeriodicInterval">25</int>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSTextField" id="1017938941">
-																<reference key="NSNextResponder" ref="715816214"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{31, 281}, {125, 14}}</string>
-																<reference key="NSSuperview" ref="715816214"/>
-																<reference key="NSWindow"/>
-																<reference key="NSNextKeyView" ref="69632604"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSTextFieldCell" key="NSCell" id="182722506">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">71303168</int>
-																	<string key="NSContents">Scrollback lines:</string>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="1017938941"/>
-																	<reference key="NSBackgroundColor" ref="1007130360"/>
-																	<reference key="NSTextColor" ref="725989266"/>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSTextField" id="69632604">
-																<reference key="NSNextResponder" ref="715816214"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{161, 279}, {50, 19}}</string>
-																<reference key="NSSuperview" ref="715816214"/>
-																<reference key="NSWindow"/>
-																<reference key="NSNextKeyView" ref="263160901"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSTextFieldCell" key="NSCell" id="871050368">
-																	<int key="NSCellFlags">-1804599231</int>
-																	<int key="NSCellFlags2">4195328</int>
-																	<string key="NSContents"/>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="69632604"/>
-																	<bool key="NSDrawsBackground">YES</bool>
-																	<reference key="NSBackgroundColor" ref="265355499"/>
-																	<reference key="NSTextColor" ref="328927124"/>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSSlider" id="823087564">
-																<reference key="NSNextResponder" ref="715816214"/>
-																<int key="NSvFlags">266</int>
-																<string key="NSFrame">{{160, 161}, {221, 17}}</string>
-																<reference key="NSSuperview" ref="715816214"/>
-																<reference key="NSWindow"/>
-																<reference key="NSNextKeyView" ref="940489567"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSSliderCell" key="NSCell" id="627787601">
-																	<int key="NSCellFlags">67371264</int>
-																	<int key="NSCellFlags2">131072</int>
-																	<object class="NSMutableString" key="NSContents">
-																		<characters key="NS.bytes"/>
-																	</object>
-																	<object class="NSFont" key="NSSupport">
-																		<string key="NSName">Helvetica</string>
-																		<double key="NSSize">12</double>
-																		<int key="NSfFlags">16</int>
-																	</object>
-																	<reference key="NSControlView" ref="823087564"/>
-																	<double key="NSMaxValue">255</double>
-																	<double key="NSMinValue">0.0</double>
-																	<double key="NSValue">201.875</double>
-																	<double key="NSAltIncValue">0.0</double>
-																	<int key="NSNumberOfTickMarks">25</int>
-																	<int key="NSTickMarkPosition">0</int>
-																	<bool key="NSAllowsTickMarkValuesOnly">YES</bool>
-																	<bool key="NSVertical">NO</bool>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSTextField" id="477134160">
-																<reference key="NSNextResponder" ref="715816214"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{17, 164}, {139, 14}}</string>
-																<reference key="NSSuperview" ref="715816214"/>
-																<reference key="NSWindow"/>
-																<reference key="NSNextKeyView" ref="823087564"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSTextFieldCell" key="NSCell" id="592705779">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">71303168</int>
-																	<string key="NSContents">Transparency:</string>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="477134160"/>
-																	<reference key="NSBackgroundColor" ref="1007130360"/>
-																	<reference key="NSTextColor" ref="725989266"/>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSButton" id="8070843">
-																<reference key="NSNextResponder" ref="715816214"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{29, 184}, {200, 19}}</string>
-																<reference key="NSSuperview" ref="715816214"/>
-																<reference key="NSWindow"/>
-																<reference key="NSNextKeyView" ref="477134160"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSButtonCell" key="NSCell" id="787527069">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">131072</int>
-																	<string key="NSContents">Transparent Windows</string>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="8070843"/>
-																	<int key="NSButtonFlags">1211912448</int>
-																	<int key="NSButtonFlags2">2</int>
-																	<reference key="NSNormalImage" ref="557231633"/>
-																	<reference key="NSAlternateImage" ref="152492997"/>
-																	<string key="NSAlternateContents"/>
-																	<string key="NSKeyEquivalent"/>
-																	<int key="NSPeriodicDelay">200</int>
-																	<int key="NSPeriodicInterval">25</int>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSTextField" id="940489567">
-																<reference key="NSNextResponder" ref="715816214"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{17, 139}, {415, 17}}</string>
-																<reference key="NSSuperview" ref="715816214"/>
-																<reference key="NSWindow"/>
-																<reference key="NSNextKeyView" ref="40697488"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSTextFieldCell" key="NSCell" id="63479885">
-																	<int key="NSCellFlags">68157504</int>
-																	<int key="NSCellFlags2">272630784</int>
-																	<string key="NSContents">Time Stamps</string>
-																	<object class="NSFont" key="NSSupport" id="60143749">
-																		<string key="NSName">LucidaGrande-Bold</string>
-																		<double key="NSSize">13</double>
-																		<int key="NSfFlags">16</int>
-																	</object>
-																	<reference key="NSControlView" ref="940489567"/>
-																	<reference key="NSBackgroundColor" ref="1007130360"/>
-																	<reference key="NSTextColor" ref="725989266"/>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSStepper" id="263160901">
-																<reference key="NSNextResponder" ref="715816214"/>
-																<int key="NSvFlags">-2147483380</int>
-																<string key="NSFrame">{{209, 273}, {19, 27}}</string>
-																<reference key="NSSuperview" ref="715816214"/>
-																<reference key="NSWindow"/>
-																<reference key="NSNextKeyView" ref="232859697"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSStepperCell" key="NSCell" id="684025955">
-																	<int key="NSCellFlags">786464</int>
-																	<int key="NSCellFlags2">0</int>
-																	<reference key="NSControlView" ref="263160901"/>
-																	<double key="NSMaxValue">100</double>
-																	<double key="NSIncrement">1</double>
-																	<bool key="NSAutorepeat">YES</bool>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSTextField" id="415446463">
-																<reference key="NSNextResponder" ref="715816214"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{17, 381}, {415, 17}}</string>
-																<reference key="NSSuperview" ref="715816214"/>
-																<reference key="NSWindow"/>
-																<reference key="NSNextKeyView" ref="17670746"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSTextFieldCell" key="NSCell" id="936918162">
-																	<int key="NSCellFlags">68157504</int>
-																	<int key="NSCellFlags2">272630784</int>
-																	<string key="NSContents">Text Box Appearance</string>
-																	<reference key="NSSupport" ref="60143749"/>
-																	<reference key="NSControlView" ref="415446463"/>
-																	<reference key="NSBackgroundColor" ref="1007130360"/>
-																	<reference key="NSTextColor" ref="725989266"/>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSTextField" id="539390510">
-																<reference key="NSNextResponder" ref="715816214"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{17, 209}, {415, 17}}</string>
-																<reference key="NSSuperview" ref="715816214"/>
-																<reference key="NSWindow"/>
-																<reference key="NSNextKeyView" ref="8070843"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSTextFieldCell" key="NSCell" id="1056138533">
-																	<int key="NSCellFlags">68157504</int>
-																	<int key="NSCellFlags2">272630784</int>
-																	<string key="NSContents">Transparency Settings</string>
-																	<reference key="NSSupport" ref="60143749"/>
-																	<reference key="NSControlView" ref="539390510"/>
-																	<reference key="NSBackgroundColor" ref="1007130360"/>
-																	<reference key="NSTextColor" ref="725989266"/>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-														</array>
-														<string key="NSFrameSize">{449, 406}</string>
-														<reference key="NSSuperview" ref="1053574686"/>
-														<reference key="NSWindow"/>
-														<reference key="NSNextKeyView" ref="415446463"/>
-													</object>
-													<reference key="NSColor" ref="1007130360"/>
-													<reference key="NSTabView" ref="1053574686"/>
-												</object>
-												<object class="NSTabViewItem" id="882238021">
-													<object class="NSView" key="NSView" id="416415920">
-														<nil key="NSNextResponder"/>
-														<int key="NSvFlags">256</int>
-														<array class="NSMutableArray" key="NSSubviews">
-															<object class="NSTextField" id="1031487992">
-																<reference key="NSNextResponder" ref="416415920"/>
-																<int key="NSvFlags">266</int>
-																<string key="NSFrame">{{199, 193}, {230, 19}}</string>
-																<reference key="NSSuperview" ref="416415920"/>
-																<reference key="NSNextKeyView" ref="824226409"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSTextFieldCell" key="NSCell" id="438036338">
-																	<int key="NSCellFlags">-1804599231</int>
-																	<int key="NSCellFlags2">4195328</int>
-																	<string key="NSContents"/>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="1031487992"/>
-																	<bool key="NSDrawsBackground">YES</bool>
-																	<reference key="NSBackgroundColor" ref="265355499"/>
-																	<reference key="NSTextColor" ref="328927124"/>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSTextField" id="1068694386">
-																<reference key="NSNextResponder" ref="416415920"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{20, 195}, {174, 14}}</string>
-																<reference key="NSSuperview" ref="416415920"/>
-																<reference key="NSNextKeyView" ref="1031487992"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSTextFieldCell" key="NSCell" id="186711920">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">71303168</int>
-																	<string key="NSContents">Nick completion suffix:</string>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="1068694386"/>
-																	<reference key="NSBackgroundColor" ref="1007130360"/>
-																	<reference key="NSTextColor" ref="725989266"/>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSButton" id="534115331">
-																<reference key="NSNextResponder" ref="416415920"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{29, 215}, {200, 19}}</string>
-																<reference key="NSSuperview" ref="416415920"/>
-																<reference key="NSNextKeyView" ref="890839872"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSButtonCell" key="NSCell" id="522132494">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">131072</int>
-																	<string key="NSContents">Nick Completion</string>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="534115331"/>
-																	<int key="NSButtonFlags">1211912448</int>
-																	<int key="NSButtonFlags2">2</int>
-																	<reference key="NSNormalImage" ref="557231633"/>
-																	<reference key="NSAlternateImage" ref="152492997"/>
-																	<string key="NSAlternateContents"/>
-																	<string key="NSKeyEquivalent"/>
-																	<int key="NSPeriodicDelay">200</int>
-																	<int key="NSPeriodicInterval">25</int>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSButton" id="1049155740">
-																<reference key="NSNextResponder" ref="416415920"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{29, 305}, {411, 19}}</string>
-																<reference key="NSSuperview" ref="416415920"/>
-																<reference key="NSNextKeyView" ref="1064535331"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSButtonCell" key="NSCell" id="159598989">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">131072</int>
-																	<string key="NSContents">Interpret %nnn as an ASCII value</string>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="1049155740"/>
-																	<int key="NSButtonFlags">1211912448</int>
-																	<int key="NSButtonFlags2">2</int>
-																	<reference key="NSNormalImage" ref="557231633"/>
-																	<reference key="NSAlternateImage" ref="152492997"/>
-																	<string key="NSAlternateContents"/>
-																	<string key="NSKeyEquivalent"/>
-																	<int key="NSPeriodicDelay">200</int>
-																	<int key="NSPeriodicInterval">25</int>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSButton" id="625485372">
-																<reference key="NSNextResponder" ref="416415920"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{29, 345}, {411, 19}}</string>
-																<reference key="NSSuperview" ref="416415920"/>
-																<reference key="NSNextKeyView" ref="186360774"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSButtonCell" key="NSCell" id="938351969">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">131072</int>
-																	<string key="NSContents">Use the Text box font and colors</string>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="625485372"/>
-																	<int key="NSButtonFlags">1211912448</int>
-																	<int key="NSButtonFlags2">2</int>
-																	<reference key="NSNormalImage" ref="557231633"/>
-																	<reference key="NSAlternateImage" ref="152492997"/>
-																	<string key="NSAlternateContents"/>
-																	<string key="NSKeyEquivalent"/>
-																	<int key="NSPeriodicDelay">200</int>
-																	<int key="NSPeriodicInterval">25</int>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSButton" id="186360774">
-																<reference key="NSNextResponder" ref="416415920"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{29, 325}, {164, 19}}</string>
-																<reference key="NSSuperview" ref="416415920"/>
-																<reference key="NSNextKeyView" ref="257956724"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSButtonCell" key="NSCell" id="844032417">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">131072</int>
-																	<string key="NSContents">Spell checking</string>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="186360774"/>
-																	<int key="NSButtonFlags">1211912448</int>
-																	<int key="NSButtonFlags2">2</int>
-																	<reference key="NSNormalImage" ref="557231633"/>
-																	<reference key="NSAlternateImage" ref="152492997"/>
-																	<string key="NSAlternateContents"/>
-																	<string key="NSKeyEquivalent"/>
-																	<int key="NSPeriodicDelay">200</int>
-																	<int key="NSPeriodicInterval">25</int>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSButton" id="257956724">
-																<reference key="NSNextResponder" ref="416415920"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{196, 325}, {120, 19}}</string>
-																<reference key="NSSuperview" ref="416415920"/>
-																<reference key="NSNextKeyView" ref="667026855"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSButtonCell" key="NSCell" id="154143973">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">131072</int>
-																	<string key="NSContents">Grammar</string>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="257956724"/>
-																	<int key="NSButtonFlags">1211912448</int>
-																	<int key="NSButtonFlags2">2</int>
-																	<reference key="NSNormalImage" ref="557231633"/>
-																	<reference key="NSAlternateImage" ref="152492997"/>
-																	<string key="NSAlternateContents"/>
-																	<string key="NSKeyEquivalent"/>
-																	<int key="NSPeriodicDelay">200</int>
-																	<int key="NSPeriodicInterval">25</int>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSButton" id="667026855">
-																<reference key="NSNextResponder" ref="416415920"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{319, 325}, {121, 19}}</string>
-																<reference key="NSSuperview" ref="416415920"/>
-																<reference key="NSNextKeyView" ref="1049155740"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSButtonCell" key="NSCell" id="391251816">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">131072</int>
-																	<string key="NSContents">Autocorrection</string>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="667026855"/>
-																	<int key="NSButtonFlags">1211912448</int>
-																	<int key="NSButtonFlags2">2</int>
-																	<reference key="NSNormalImage" ref="557231633"/>
-																	<reference key="NSAlternateImage" ref="152492997"/>
-																	<string key="NSAlternateContents"/>
-																	<string key="NSKeyEquivalent"/>
-																	<int key="NSPeriodicDelay">200</int>
-																	<int key="NSPeriodicInterval">25</int>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSButton" id="1064535331">
-																<reference key="NSNextResponder" ref="416415920"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{29, 285}, {411, 19}}</string>
-																<reference key="NSSuperview" ref="416415920"/>
-																<reference key="NSNextKeyView" ref="454194464"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSButtonCell" key="NSCell" id="486311972">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">131072</int>
-																	<string key="NSContents">Interpret %C, %B as Color, Bold etc</string>
-																	<object class="NSFont" key="NSSupport" id="867044200">
-																		<string key="NSName">LucidaGrande</string>
-																		<double key="NSSize">11</double>
-																		<int key="NSfFlags">16</int>
-																	</object>
-																	<reference key="NSControlView" ref="1064535331"/>
-																	<int key="NSButtonFlags">1211912448</int>
-																	<int key="NSButtonFlags2">2</int>
-																	<reference key="NSNormalImage" ref="557231633"/>
-																	<reference key="NSAlternateImage" ref="152492997"/>
-																	<string key="NSAlternateContents"/>
-																	<string key="NSKeyEquivalent"/>
-																	<int key="NSPeriodicDelay">200</int>
-																	<int key="NSPeriodicInterval">25</int>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSButton" id="890839872">
-																<reference key="NSNextResponder" ref="416415920"/>
-																<int key="NSvFlags">269</int>
-																<string key="NSFrame">{{231, 215}, {200, 19}}</string>
-																<reference key="NSSuperview" ref="416415920"/>
-																<reference key="NSNextKeyView" ref="1068694386"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSButtonCell" key="NSCell" id="368416592">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">131072</int>
-																	<string key="NSContents">Suffix style nick completion</string>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="890839872"/>
-																	<int key="NSButtonFlags">1211912448</int>
-																	<int key="NSButtonFlags2">2</int>
-																	<reference key="NSNormalImage" ref="557231633"/>
-																	<reference key="NSAlternateImage" ref="152492997"/>
-																	<string key="NSAlternateContents"/>
-																	<string key="NSKeyEquivalent"/>
-																	<int key="NSPeriodicDelay">200</int>
-																	<int key="NSPeriodicInterval">25</int>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSButton" id="515286899">
-																<reference key="NSNextResponder" ref="416415920"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{29, 146}, {411, 19}}</string>
-																<reference key="NSSuperview" ref="416415920"/>
-																<reference key="NSNextKeyView" ref="665353132"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSButtonCell" key="NSCell" id="646718756">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">131072</int>
-																	<string key="NSContents">Scroll tab-key completion choices</string>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="515286899"/>
-																	<int key="NSButtonFlags">1211912448</int>
-																	<int key="NSButtonFlags2">2</int>
-																	<reference key="NSNormalImage" ref="557231633"/>
-																	<reference key="NSAlternateImage" ref="152492997"/>
-																	<string key="NSAlternateContents"/>
-																	<string key="NSKeyEquivalent"/>
-																	<int key="NSPeriodicDelay">200</int>
-																	<int key="NSPeriodicInterval">25</int>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSTextField" id="824226409">
-																<reference key="NSNextResponder" ref="416415920"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{20, 170}, {174, 17}}</string>
-																<reference key="NSSuperview" ref="416415920"/>
-																<reference key="NSNextKeyView" ref="448930768"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSTextFieldCell" key="NSCell" id="481179084">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">71303168</int>
-																	<string key="NSContents">Nick completion sorted:</string>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="824226409"/>
-																	<reference key="NSBackgroundColor" ref="1007130360"/>
-																	<reference key="NSTextColor" ref="725989266"/>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSPopUpButton" id="448930768">
-																<reference key="NSNextResponder" ref="416415920"/>
-																<int key="NSvFlags">266</int>
-																<string key="NSFrame">{{196, 166}, {236, 22}}</string>
-																<reference key="NSSuperview" ref="416415920"/>
-																<reference key="NSNextKeyView" ref="515286899"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSPopUpButtonCell" key="NSCell" id="1005042470">
-																	<int key="NSCellFlags">-2076180416</int>
-																	<int key="NSCellFlags2">132096</int>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="448930768"/>
-																	<int key="NSButtonFlags">-2038284288</int>
-																	<int key="NSButtonFlags2">1</int>
-																	<reference key="NSAlternateImage" ref="26"/>
-																	<string key="NSAlternateContents"/>
-																	<object class="NSMutableString" key="NSKeyEquivalent">
-																		<characters key="NS.bytes"/>
-																	</object>
-																	<int key="NSPeriodicDelay">400</int>
-																	<int key="NSPeriodicInterval">75</int>
-																	<object class="NSMenuItem" key="NSMenuItem" id="601422765">
-																		<reference key="NSMenu" ref="82319767"/>
-																		<string key="NSTitle">A-Z</string>
-																		<string key="NSKeyEquiv"/>
-																		<int key="NSKeyEquivModMask">1048576</int>
-																		<int key="NSMnemonicLoc">2147483647</int>
-																		<int key="NSState">1</int>
-																		<object class="NSCustomResource" key="NSOnImage" id="123016255">
-																			<string key="NSClassName">NSImage</string>
-																			<string key="NSResourceName">NSMenuCheckmark</string>
-																		</object>
-																		<object class="NSCustomResource" key="NSMixedImage" id="138212614">
-																			<string key="NSClassName">NSImage</string>
-																			<string key="NSResourceName">NSMenuMixedState</string>
-																		</object>
-																		<string key="NSAction">_popUpItemAction:</string>
-																		<reference key="NSTarget" ref="1005042470"/>
-																	</object>
-																	<bool key="NSMenuItemRespectAlignment">YES</bool>
-																	<object class="NSMenu" key="NSMenu" id="82319767">
-																		<string key="NSTitle"/>
-																		<array class="NSMutableArray" key="NSMenuItems">
-																			<reference ref="601422765"/>
-																			<object class="NSMenuItem" id="661175652">
-																				<reference key="NSMenu" ref="82319767"/>
-																				<string key="NSTitle">Last-spoke order</string>
-																				<string key="NSKeyEquiv"/>
-																				<int key="NSKeyEquivModMask">1048576</int>
-																				<int key="NSMnemonicLoc">2147483647</int>
-																				<reference key="NSOnImage" ref="123016255"/>
-																				<reference key="NSMixedImage" ref="138212614"/>
-																				<string key="NSAction">_popUpItemAction:</string>
-																				<int key="NSTag">1</int>
-																				<reference key="NSTarget" ref="1005042470"/>
-																			</object>
-																		</array>
-																	</object>
-																	<int key="NSPreferredEdge">3</int>
-																	<bool key="NSUsesItemFromMenu">YES</bool>
-																	<bool key="NSAltersState">YES</bool>
-																	<int key="NSArrowPosition">1</int>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSTextField" id="489866395">
-																<reference key="NSNextResponder" ref="416415920"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{17, 369}, {415, 17}}</string>
-																<reference key="NSSuperview" ref="416415920"/>
-																<reference key="NSNextKeyView" ref="625485372"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSTextFieldCell" key="NSCell" id="455308470">
-																	<int key="NSCellFlags">68157504</int>
-																	<int key="NSCellFlags2">272630784</int>
-																	<string key="NSContents">Input box</string>
-																	<reference key="NSSupport" ref="60143749"/>
-																	<reference key="NSControlView" ref="489866395"/>
-																	<reference key="NSBackgroundColor" ref="1007130360"/>
-																	<reference key="NSTextColor" ref="725989266"/>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSTextField" id="454194464">
-																<reference key="NSNextResponder" ref="416415920"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{17, 239}, {415, 17}}</string>
-																<reference key="NSSuperview" ref="416415920"/>
-																<reference key="NSNextKeyView" ref="534115331"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSTextFieldCell" key="NSCell" id="703463092">
-																	<int key="NSCellFlags">68157504</int>
-																	<int key="NSCellFlags2">272630784</int>
-																	<string key="NSContents">Nick Completion</string>
-																	<reference key="NSSupport" ref="60143749"/>
-																	<reference key="NSControlView" ref="454194464"/>
-																	<reference key="NSBackgroundColor" ref="1007130360"/>
-																	<reference key="NSTextColor" ref="725989266"/>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-														</array>
-														<string key="NSFrameSize">{449, 406}</string>
-														<reference key="NSNextKeyView" ref="489866395"/>
-													</object>
-													<reference key="NSColor" ref="1007130360"/>
-													<reference key="NSTabView" ref="1053574686"/>
-												</object>
-												<object class="NSTabViewItem" id="1040782865">
-													<object class="NSView" key="NSView" id="19718304">
-														<nil key="NSNextResponder"/>
-														<int key="NSvFlags">256</int>
-														<array class="NSMutableArray" key="NSSubviews">
-															<object class="NSTextField" id="67211373">
-																<reference key="NSNextResponder" ref="19718304"/>
-																<int key="NSvFlags">266</int>
-																<string key="NSFrame">{{229, 137}, {200, 19}}</string>
-																<reference key="NSSuperview" ref="19718304"/>
-																<reference key="NSNextKeyView" ref="1053574686"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSTextFieldCell" key="NSCell" id="146368653">
-																	<int key="NSCellFlags">-1804599231</int>
-																	<int key="NSCellFlags2">4195328</int>
-																	<string key="NSContents"/>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="67211373"/>
-																	<bool key="NSDrawsBackground">YES</bool>
-																	<reference key="NSBackgroundColor" ref="265355499"/>
-																	<reference key="NSTextColor" ref="328927124"/>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSTextField" id="542998689">
-																<reference key="NSNextResponder" ref="19718304"/>
-																<int key="NSvFlags">266</int>
-																<string key="NSFrame">{{229, 186}, {60, 19}}</string>
-																<reference key="NSSuperview" ref="19718304"/>
-																<reference key="NSNextKeyView" ref="406095088"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSTextFieldCell" key="NSCell" id="550969866">
-																	<int key="NSCellFlags">-1804599231</int>
-																	<int key="NSCellFlags2">4195328</int>
-																	<string key="NSContents"/>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="542998689"/>
-																	<bool key="NSDrawsBackground">YES</bool>
-																	<reference key="NSBackgroundColor" ref="265355499"/>
-																	<reference key="NSTextColor" ref="328927124"/>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSTextField" id="207844218">
-																<reference key="NSNextResponder" ref="19718304"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{17, 136}, {207, 17}}</string>
-																<reference key="NSSuperview" ref="19718304"/>
-																<reference key="NSNextKeyView" ref="67211373"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSTextFieldCell" key="NSCell" id="621951969">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">71303168</int>
-																	<string key="NSContents">Execute command:</string>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="207844218"/>
-																	<reference key="NSBackgroundColor" ref="1007130360"/>
-																	<reference key="NSTextColor" ref="725989266"/>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSTextField" id="842802870">
-																<reference key="NSNextResponder" ref="19718304"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{29, 258}, {195, 17}}</string>
-																<reference key="NSSuperview" ref="19718304"/>
-																<reference key="NSNextKeyView" ref="544344533"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSTextFieldCell" key="NSCell" id="976186580">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">71303168</int>
-																	<string key="NSContents">User list sorted by:</string>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="842802870"/>
-																	<reference key="NSBackgroundColor" ref="1007130360"/>
-																	<reference key="NSTextColor" ref="725989266"/>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSTextField" id="1030426936">
-																<reference key="NSNextResponder" ref="19718304"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{-3, 188}, {227, 14}}</string>
-																<reference key="NSSuperview" ref="19718304"/>
-																<reference key="NSNextKeyView" ref="542998689"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSTextFieldCell" key="NSCell" id="928059081">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">71303168</int>
-																	<string key="NSContents">On channels smaller than:</string>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="1030426936"/>
-																	<reference key="NSBackgroundColor" ref="1007130360"/>
-																	<reference key="NSTextColor" ref="725989266"/>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSPopUpButton" id="544344533">
-																<reference key="NSNextResponder" ref="19718304"/>
-																<int key="NSvFlags">266</int>
-																<string key="NSFrame">{{226, 254}, {206, 22}}</string>
-																<reference key="NSSuperview" ref="19718304"/>
-																<reference key="NSNextKeyView" ref="86511413"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSPopUpButtonCell" key="NSCell" id="893064887">
-																	<int key="NSCellFlags">-2076180416</int>
-																	<int key="NSCellFlags2">132096</int>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="544344533"/>
-																	<int key="NSButtonFlags">-2038284288</int>
-																	<int key="NSButtonFlags2">1</int>
-																	<reference key="NSAlternateImage" ref="26"/>
-																	<string key="NSAlternateContents"/>
-																	<object class="NSMutableString" key="NSKeyEquivalent">
-																		<characters key="NS.bytes"/>
-																	</object>
-																	<int key="NSPeriodicDelay">400</int>
-																	<int key="NSPeriodicInterval">75</int>
-																	<object class="NSMenuItem" key="NSMenuItem" id="54656864">
-																		<reference key="NSMenu" ref="215914061"/>
-																		<string key="NSTitle">A-Z, Ops first</string>
-																		<string key="NSKeyEquiv"/>
-																		<int key="NSKeyEquivModMask">1048576</int>
-																		<int key="NSMnemonicLoc">2147483647</int>
-																		<int key="NSState">1</int>
-																		<reference key="NSOnImage" ref="123016255"/>
-																		<reference key="NSMixedImage" ref="138212614"/>
-																		<string key="NSAction">_popUpItemAction:</string>
-																		<reference key="NSTarget" ref="893064887"/>
-																	</object>
-																	<bool key="NSMenuItemRespectAlignment">YES</bool>
-																	<object class="NSMenu" key="NSMenu" id="215914061">
-																		<string key="NSTitle"/>
-																		<array class="NSMutableArray" key="NSMenuItems">
-																			<reference ref="54656864"/>
-																			<object class="NSMenuItem" id="298569940">
-																				<reference key="NSMenu" ref="215914061"/>
-																				<string key="NSTitle">A-Z</string>
-																				<string key="NSKeyEquiv"/>
-																				<int key="NSKeyEquivModMask">1048576</int>
-																				<int key="NSMnemonicLoc">2147483647</int>
-																				<reference key="NSOnImage" ref="123016255"/>
-																				<reference key="NSMixedImage" ref="138212614"/>
-																				<string key="NSAction">_popUpItemAction:</string>
-																				<reference key="NSTarget" ref="893064887"/>
-																			</object>
-																			<object class="NSMenuItem" id="230994184">
-																				<reference key="NSMenu" ref="215914061"/>
-																				<string key="NSTitle">Z-A, Ops last</string>
-																				<string key="NSKeyEquiv"/>
-																				<int key="NSKeyEquivModMask">1048576</int>
-																				<int key="NSMnemonicLoc">2147483647</int>
-																				<reference key="NSOnImage" ref="123016255"/>
-																				<reference key="NSMixedImage" ref="138212614"/>
-																				<string key="NSAction">_popUpItemAction:</string>
-																				<reference key="NSTarget" ref="893064887"/>
-																			</object>
-																			<object class="NSMenuItem" id="131388204">
-																				<reference key="NSMenu" ref="215914061"/>
-																				<string key="NSTitle">Z-A</string>
-																				<string key="NSKeyEquiv"/>
-																				<int key="NSKeyEquivModMask">1048576</int>
-																				<int key="NSMnemonicLoc">2147483647</int>
-																				<reference key="NSOnImage" ref="123016255"/>
-																				<reference key="NSMixedImage" ref="138212614"/>
-																				<string key="NSAction">_popUpItemAction:</string>
-																				<reference key="NSTarget" ref="893064887"/>
-																			</object>
-																			<object class="NSMenuItem" id="361965654">
-																				<reference key="NSMenu" ref="215914061"/>
-																				<string key="NSTitle">Unsorted</string>
-																				<string key="NSKeyEquiv"/>
-																				<int key="NSKeyEquivModMask">1048576</int>
-																				<int key="NSMnemonicLoc">2147483647</int>
-																				<reference key="NSOnImage" ref="123016255"/>
-																				<reference key="NSMixedImage" ref="138212614"/>
-																				<string key="NSAction">_popUpItemAction:</string>
-																				<reference key="NSTarget" ref="893064887"/>
-																			</object>
-																		</array>
-																	</object>
-																	<int key="NSPreferredEdge">3</int>
-																	<bool key="NSUsesItemFromMenu">YES</bool>
-																	<bool key="NSAltersState">YES</bool>
-																	<int key="NSArrowPosition">1</int>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSButton" id="843004622">
-																<reference key="NSNextResponder" ref="19718304"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{29, 281}, {394, 19}}</string>
-																<reference key="NSSuperview" ref="19718304"/>
-																<reference key="NSNextKeyView" ref="842802870"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSButtonCell" key="NSCell" id="642818869">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">131072</int>
-																	<string key="NSContents">Userlist buttons enabled</string>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="843004622"/>
-																	<int key="NSButtonFlags">1211912448</int>
-																	<int key="NSButtonFlags2">2</int>
-																	<reference key="NSNormalImage" ref="557231633"/>
-																	<reference key="NSAlternateImage" ref="152492997"/>
-																	<string key="NSAlternateContents"/>
-																	<string key="NSKeyEquivalent"/>
-																	<int key="NSPeriodicDelay">200</int>
-																	<int key="NSPeriodicInterval">25</int>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSButton" id="702422028">
-																<reference key="NSNextResponder" ref="19718304"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{29, 302}, {394, 19}}</string>
-																<reference key="NSSuperview" ref="19718304"/>
-																<reference key="NSNextKeyView" ref="843004622"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSButtonCell" key="NSCell" id="673213488">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">131072</int>
-																	<string key="NSContents">Hide user list</string>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="702422028"/>
-																	<int key="NSButtonFlags">1211912448</int>
-																	<int key="NSButtonFlags2">2</int>
-																	<reference key="NSNormalImage" ref="557231633"/>
-																	<reference key="NSAlternateImage" ref="152492997"/>
-																	<string key="NSAlternateContents"/>
-																	<string key="NSKeyEquivalent"/>
-																	<int key="NSPeriodicDelay">200</int>
-																	<int key="NSPeriodicInterval">25</int>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSButton" id="846995571">
-																<reference key="NSNextResponder" ref="19718304"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{29, 323}, {411, 19}}</string>
-																<reference key="NSSuperview" ref="19718304"/>
-																<reference key="NSNextKeyView" ref="702422028"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSButtonCell" key="NSCell" id="694790679">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">131072</int>
-																	<string key="NSContents">Use the Text box font and colors</string>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="846995571"/>
-																	<int key="NSButtonFlags">1211912448</int>
-																	<int key="NSButtonFlags2">2</int>
-																	<reference key="NSNormalImage" ref="557231633"/>
-																	<reference key="NSAlternateImage" ref="152492997"/>
-																	<string key="NSAlternateContents"/>
-																	<string key="NSKeyEquivalent"/>
-																	<int key="NSPeriodicDelay">200</int>
-																	<int key="NSPeriodicInterval">25</int>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSButton" id="367627207">
-																<reference key="NSNextResponder" ref="19718304"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{29, 208}, {394, 19}}</string>
-																<reference key="NSSuperview" ref="19718304"/>
-																<reference key="NSNextKeyView" ref="1030426936"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSButtonCell" key="NSCell" id="959996177">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">131072</int>
-																	<string key="NSContents">Track the Away status of users and mark them in a different color</string>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="367627207"/>
-																	<int key="NSButtonFlags">1211912448</int>
-																	<int key="NSButtonFlags2">2</int>
-																	<reference key="NSNormalImage" ref="557231633"/>
-																	<reference key="NSAlternateImage" ref="152492997"/>
-																	<string key="NSAlternateContents"/>
-																	<string key="NSKeyEquivalent"/>
-																	<int key="NSPeriodicDelay">200</int>
-																	<int key="NSPeriodicInterval">25</int>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSButton" id="443451250">
-																<reference key="NSNextResponder" ref="19718304"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{29, 344}, {394, 19}}</string>
-																<reference key="NSSuperview" ref="19718304"/>
-																<reference key="NSNextKeyView" ref="846995571"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSButtonCell" key="NSCell" id="1017031721">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">131072</int>
-																	<string key="NSContents">Show hostnames in user list</string>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="443451250"/>
-																	<int key="NSButtonFlags">1211912448</int>
-																	<int key="NSButtonFlags2">2</int>
-																	<reference key="NSNormalImage" ref="557231633"/>
-																	<reference key="NSAlternateImage" ref="152492997"/>
-																	<string key="NSAlternateContents"/>
-																	<string key="NSKeyEquivalent"/>
-																	<int key="NSPeriodicDelay">200</int>
-																	<int key="NSPeriodicInterval">25</int>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSTextField" id="450481229">
-																<reference key="NSNextResponder" ref="19718304"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{17, 369}, {242, 17}}</string>
-																<reference key="NSSuperview" ref="19718304"/>
-																<reference key="NSNextKeyView" ref="443451250"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSTextFieldCell" key="NSCell" id="616220944">
-																	<int key="NSCellFlags">68157504</int>
-																	<int key="NSCellFlags2">272630784</int>
-																	<string key="NSContents">User List</string>
-																	<reference key="NSSupport" ref="60143749"/>
-																	<reference key="NSControlView" ref="450481229"/>
-																	<reference key="NSBackgroundColor" ref="1007130360"/>
-																	<reference key="NSTextColor" ref="725989266"/>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSTextField" id="406095088">
-																<reference key="NSNextResponder" ref="19718304"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{17, 161}, {342, 17}}</string>
-																<reference key="NSSuperview" ref="19718304"/>
-																<reference key="NSNextKeyView" ref="207844218"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSTextFieldCell" key="NSCell" id="247302629">
-																	<int key="NSCellFlags">68157504</int>
-																	<int key="NSCellFlags2">272630784</int>
-																	<string key="NSContents">Action Upon Double Click</string>
-																	<reference key="NSSupport" ref="60143749"/>
-																	<reference key="NSControlView" ref="406095088"/>
-																	<reference key="NSBackgroundColor" ref="1007130360"/>
-																	<reference key="NSTextColor" ref="725989266"/>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSTextField" id="86511413">
-																<reference key="NSNextResponder" ref="19718304"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{17, 233}, {342, 17}}</string>
-																<reference key="NSSuperview" ref="19718304"/>
-																<reference key="NSNextKeyView" ref="367627207"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSTextFieldCell" key="NSCell" id="562744354">
-																	<int key="NSCellFlags">68157504</int>
-																	<int key="NSCellFlags2">272630784</int>
-																	<string key="NSContents">Away tracking</string>
-																	<reference key="NSSupport" ref="60143749"/>
-																	<reference key="NSControlView" ref="86511413"/>
-																	<reference key="NSBackgroundColor" ref="1007130360"/>
-																	<reference key="NSTextColor" ref="725989266"/>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-														</array>
-														<string key="NSFrameSize">{449, 406}</string>
-														<reference key="NSNextKeyView" ref="450481229"/>
-													</object>
-													<reference key="NSColor" ref="1007130360"/>
-													<reference key="NSTabView" ref="1053574686"/>
-												</object>
-												<object class="NSTabViewItem" id="40875324">
-													<object class="NSView" key="NSView" id="820917927">
-														<nil key="NSNextResponder"/>
-														<int key="NSvFlags">292</int>
-														<array class="NSMutableArray" key="NSSubviews">
-															<object class="NSTextField" id="1055300200">
-																<reference key="NSNextResponder" ref="820917927"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{22, 119}, {144, 17}}</string>
-																<reference key="NSSuperview" ref="820917927"/>
-																<reference key="NSNextKeyView" ref="859866171"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSTextFieldCell" key="NSCell" id="557873526">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">71303168</int>
-																	<string key="NSContents">Open channels in:</string>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="1055300200"/>
-																	<reference key="NSBackgroundColor" ref="1007130360"/>
-																	<reference key="NSTextColor" ref="725989266"/>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSPopUpButton" id="859866171">
-																<reference key="NSNextResponder" ref="820917927"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{168, 116}, {106, 22}}</string>
-																<reference key="NSSuperview" ref="820917927"/>
-																<reference key="NSNextKeyView" ref="754076012"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSPopUpButtonCell" key="NSCell" id="1050250763">
-																	<int key="NSCellFlags">-2076180416</int>
-																	<int key="NSCellFlags2">132096</int>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="859866171"/>
-																	<int key="NSButtonFlags">-2038284288</int>
-																	<int key="NSButtonFlags2">1</int>
-																	<reference key="NSAlternateImage" ref="26"/>
-																	<string key="NSAlternateContents"/>
-																	<object class="NSMutableString" key="NSKeyEquivalent">
-																		<characters key="NS.bytes"/>
-																	</object>
-																	<int key="NSPeriodicDelay">400</int>
-																	<int key="NSPeriodicInterval">75</int>
-																	<object class="NSMenuItem" key="NSMenuItem" id="320237679">
-																		<reference key="NSMenu" ref="778662096"/>
-																		<string key="NSTitle">Tabs</string>
-																		<string key="NSKeyEquiv"/>
-																		<int key="NSKeyEquivModMask">1048576</int>
-																		<int key="NSMnemonicLoc">2147483647</int>
-																		<int key="NSState">1</int>
-																		<reference key="NSOnImage" ref="123016255"/>
-																		<reference key="NSMixedImage" ref="138212614"/>
-																		<string key="NSAction">_popUpItemAction:</string>
-																		<reference key="NSTarget" ref="1050250763"/>
-																	</object>
-																	<bool key="NSMenuItemRespectAlignment">YES</bool>
-																	<object class="NSMenu" key="NSMenu" id="778662096">
-																		<string key="NSTitle"/>
-																		<array class="NSMutableArray" key="NSMenuItems">
-																			<object class="NSMenuItem" id="513519977">
-																				<reference key="NSMenu" ref="778662096"/>
-																				<string key="NSTitle">Windows</string>
-																				<string key="NSKeyEquiv"/>
-																				<int key="NSKeyEquivModMask">1048576</int>
-																				<int key="NSMnemonicLoc">2147483647</int>
-																				<reference key="NSOnImage" ref="123016255"/>
-																				<reference key="NSMixedImage" ref="138212614"/>
-																				<string key="NSAction">_popUpItemAction:</string>
-																				<reference key="NSTarget" ref="1050250763"/>
-																			</object>
-																			<reference ref="320237679"/>
-																		</array>
-																	</object>
-																	<int key="NSSelectedIndex">1</int>
-																	<int key="NSPreferredEdge">3</int>
-																	<bool key="NSUsesItemFromMenu">YES</bool>
-																	<bool key="NSAltersState">YES</bool>
-																	<int key="NSArrowPosition">1</int>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSTextField" id="754076012">
-																<reference key="NSNextResponder" ref="820917927"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{22, 94}, {144, 17}}</string>
-																<reference key="NSSuperview" ref="820917927"/>
-																<reference key="NSNextKeyView" ref="601992312"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSTextFieldCell" key="NSCell" id="46483213">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">71303168</int>
-																	<string key="NSContents">Open dialogs in:</string>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="754076012"/>
-																	<reference key="NSBackgroundColor" ref="1007130360"/>
-																	<reference key="NSTextColor" ref="725989266"/>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSPopUpButton" id="601992312">
-																<reference key="NSNextResponder" ref="820917927"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{168, 91}, {106, 22}}</string>
-																<reference key="NSSuperview" ref="820917927"/>
-																<reference key="NSNextKeyView" ref="1021883353"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSPopUpButtonCell" key="NSCell" id="744867520">
-																	<int key="NSCellFlags">-2076180416</int>
-																	<int key="NSCellFlags2">132096</int>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="601992312"/>
-																	<int key="NSButtonFlags">-2038284288</int>
-																	<int key="NSButtonFlags2">1</int>
-																	<reference key="NSAlternateImage" ref="26"/>
-																	<string key="NSAlternateContents"/>
-																	<object class="NSMutableString" key="NSKeyEquivalent">
-																		<characters key="NS.bytes"/>
-																	</object>
-																	<int key="NSPeriodicDelay">400</int>
-																	<int key="NSPeriodicInterval">75</int>
-																	<object class="NSMenuItem" key="NSMenuItem" id="419088361">
-																		<reference key="NSMenu" ref="506597454"/>
-																		<string key="NSTitle">Tabs</string>
-																		<string key="NSKeyEquiv"/>
-																		<int key="NSKeyEquivModMask">1048576</int>
-																		<int key="NSMnemonicLoc">2147483647</int>
-																		<int key="NSState">1</int>
-																		<reference key="NSOnImage" ref="123016255"/>
-																		<reference key="NSMixedImage" ref="138212614"/>
-																		<string key="NSAction">_popUpItemAction:</string>
-																		<reference key="NSTarget" ref="744867520"/>
-																	</object>
-																	<bool key="NSMenuItemRespectAlignment">YES</bool>
-																	<object class="NSMenu" key="NSMenu" id="506597454">
-																		<string key="NSTitle"/>
-																		<array class="NSMutableArray" key="NSMenuItems">
-																			<object class="NSMenuItem" id="507982522">
-																				<reference key="NSMenu" ref="506597454"/>
-																				<string key="NSTitle">Windows</string>
-																				<string key="NSKeyEquiv"/>
-																				<int key="NSKeyEquivModMask">1048576</int>
-																				<int key="NSMnemonicLoc">2147483647</int>
-																				<reference key="NSOnImage" ref="123016255"/>
-																				<reference key="NSMixedImage" ref="138212614"/>
-																				<string key="NSAction">_popUpItemAction:</string>
-																				<reference key="NSTarget" ref="744867520"/>
-																			</object>
-																			<reference ref="419088361"/>
-																		</array>
-																	</object>
-																	<int key="NSSelectedIndex">1</int>
-																	<int key="NSPreferredEdge">3</int>
-																	<bool key="NSUsesItemFromMenu">YES</bool>
-																	<bool key="NSAltersState">YES</bool>
-																	<int key="NSArrowPosition">1</int>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSTextField" id="1021883353">
-																<reference key="NSNextResponder" ref="820917927"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{22, 69}, {144, 17}}</string>
-																<reference key="NSSuperview" ref="820917927"/>
-																<reference key="NSNextKeyView" ref="375046315"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSTextFieldCell" key="NSCell" id="200405955">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">71303168</int>
-																	<string key="NSContents">Open utilities in:</string>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="1021883353"/>
-																	<reference key="NSBackgroundColor" ref="1007130360"/>
-																	<reference key="NSTextColor" ref="725989266"/>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSPopUpButton" id="375046315">
-																<reference key="NSNextResponder" ref="820917927"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{168, 66}, {106, 22}}</string>
-																<reference key="NSSuperview" ref="820917927"/>
-																<reference key="NSNextKeyView" ref="1053574686"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSPopUpButtonCell" key="NSCell" id="397070298">
-																	<int key="NSCellFlags">-2076180416</int>
-																	<int key="NSCellFlags2">132096</int>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="375046315"/>
-																	<int key="NSButtonFlags">-2038284288</int>
-																	<int key="NSButtonFlags2">1</int>
-																	<reference key="NSAlternateImage" ref="26"/>
-																	<string key="NSAlternateContents"/>
-																	<object class="NSMutableString" key="NSKeyEquivalent">
-																		<characters key="NS.bytes"/>
-																	</object>
-																	<int key="NSPeriodicDelay">400</int>
-																	<int key="NSPeriodicInterval">75</int>
-																	<object class="NSMenuItem" key="NSMenuItem" id="457365082">
-																		<reference key="NSMenu" ref="169570948"/>
-																		<string key="NSTitle">Tabs</string>
-																		<string key="NSKeyEquiv"/>
-																		<int key="NSKeyEquivModMask">1048576</int>
-																		<int key="NSMnemonicLoc">2147483647</int>
-																		<int key="NSState">1</int>
-																		<reference key="NSOnImage" ref="123016255"/>
-																		<reference key="NSMixedImage" ref="138212614"/>
-																		<string key="NSAction">_popUpItemAction:</string>
-																		<reference key="NSTarget" ref="397070298"/>
-																	</object>
-																	<bool key="NSMenuItemRespectAlignment">YES</bool>
-																	<object class="NSMenu" key="NSMenu" id="169570948">
-																		<string key="NSTitle"/>
-																		<array class="NSMutableArray" key="NSMenuItems">
-																			<object class="NSMenuItem" id="655875288">
-																				<reference key="NSMenu" ref="169570948"/>
-																				<string key="NSTitle">Windows</string>
-																				<string key="NSKeyEquiv"/>
-																				<int key="NSKeyEquivModMask">1048576</int>
-																				<int key="NSMnemonicLoc">2147483647</int>
-																				<reference key="NSOnImage" ref="123016255"/>
-																				<reference key="NSMixedImage" ref="138212614"/>
-																				<string key="NSAction">_popUpItemAction:</string>
-																				<reference key="NSTarget" ref="397070298"/>
-																			</object>
-																			<reference ref="457365082"/>
-																		</array>
-																	</object>
-																	<int key="NSSelectedIndex">1</int>
-																	<int key="NSPreferredEdge">3</int>
-																	<bool key="NSUsesItemFromMenu">YES</bool>
-																	<bool key="NSAltersState">YES</bool>
-																	<int key="NSArrowPosition">1</int>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSPopUpButton" id="100869595">
-																<reference key="NSNextResponder" ref="820917927"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{168, 206}, {106, 22}}</string>
-																<reference key="NSSuperview" ref="820917927"/>
-																<reference key="NSNextKeyView" ref="1005457499"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSPopUpButtonCell" key="NSCell" id="580378339">
-																	<int key="NSCellFlags">-2076180416</int>
-																	<int key="NSCellFlags2">132096</int>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="100869595"/>
-																	<int key="NSButtonFlags">-2038284288</int>
-																	<int key="NSButtonFlags2">1</int>
-																	<reference key="NSAlternateImage" ref="26"/>
-																	<string key="NSAlternateContents"/>
-																	<object class="NSMutableString" key="NSKeyEquivalent">
-																		<characters key="NS.bytes"/>
-																	</object>
-																	<int key="NSPeriodicDelay">400</int>
-																	<int key="NSPeriodicInterval">75</int>
-																	<object class="NSMenuItem" key="NSMenuItem" id="878449292">
-																		<reference key="NSMenu" ref="998492064"/>
-																		<string key="NSTitle">Bottom</string>
-																		<string key="NSKeyEquiv"/>
-																		<int key="NSKeyEquivModMask">1048576</int>
-																		<int key="NSMnemonicLoc">2147483647</int>
-																		<int key="NSState">1</int>
-																		<reference key="NSOnImage" ref="123016255"/>
-																		<reference key="NSMixedImage" ref="138212614"/>
-																		<string key="NSAction">_popUpItemAction:</string>
-																		<reference key="NSTarget" ref="580378339"/>
-																	</object>
-																	<bool key="NSMenuItemRespectAlignment">YES</bool>
-																	<object class="NSMenu" key="NSMenu" id="998492064">
-																		<string key="NSTitle"/>
-																		<array class="NSMutableArray" key="NSMenuItems">
-																			<reference ref="878449292"/>
-																			<object class="NSMenuItem" id="239081209">
-																				<reference key="NSMenu" ref="998492064"/>
-																				<string key="NSTitle">Top</string>
-																				<string key="NSKeyEquiv"/>
-																				<int key="NSKeyEquivModMask">1048576</int>
-																				<int key="NSMnemonicLoc">2147483647</int>
-																				<reference key="NSOnImage" ref="123016255"/>
-																				<reference key="NSMixedImage" ref="138212614"/>
-																				<string key="NSAction">_popUpItemAction:</string>
-																				<reference key="NSTarget" ref="580378339"/>
-																			</object>
-																			<object class="NSMenuItem" id="158703308">
-																				<reference key="NSMenu" ref="998492064"/>
-																				<string key="NSTitle">Right</string>
-																				<string key="NSKeyEquiv"/>
-																				<int key="NSKeyEquivModMask">1048576</int>
-																				<int key="NSMnemonicLoc">2147483647</int>
-																				<reference key="NSOnImage" ref="123016255"/>
-																				<reference key="NSMixedImage" ref="138212614"/>
-																				<string key="NSAction">_popUpItemAction:</string>
-																				<reference key="NSTarget" ref="580378339"/>
-																			</object>
-																			<object class="NSMenuItem" id="524656986">
-																				<reference key="NSMenu" ref="998492064"/>
-																				<string key="NSTitle">Left</string>
-																				<string key="NSKeyEquiv"/>
-																				<int key="NSKeyEquivModMask">1048576</int>
-																				<int key="NSMnemonicLoc">2147483647</int>
-																				<reference key="NSOnImage" ref="123016255"/>
-																				<reference key="NSMixedImage" ref="138212614"/>
-																				<string key="NSAction">_popUpItemAction:</string>
-																				<reference key="NSTarget" ref="580378339"/>
-																			</object>
-																		</array>
-																	</object>
-																	<int key="NSPreferredEdge">3</int>
-																	<bool key="NSUsesItemFromMenu">YES</bool>
-																	<bool key="NSAltersState">YES</bool>
-																	<int key="NSArrowPosition">1</int>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSPopUpButton" id="317580382">
-																<reference key="NSNextResponder" ref="820917927"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{168, 364}, {106, 22}}</string>
-																<reference key="NSSuperview" ref="820917927"/>
-																<reference key="NSNextKeyView" ref="647588713"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSPopUpButtonCell" key="NSCell" id="661204790">
-																	<int key="NSCellFlags">-2076180416</int>
-																	<int key="NSCellFlags2">132096</int>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="317580382"/>
-																	<int key="NSButtonFlags">-2038284288</int>
-																	<int key="NSButtonFlags2">1</int>
-																	<reference key="NSAlternateImage" ref="26"/>
-																	<string key="NSAlternateContents"/>
-																	<object class="NSMutableString" key="NSKeyEquivalent">
-																		<characters key="NS.bytes"/>
-																	</object>
-																	<int key="NSPeriodicDelay">400</int>
-																	<int key="NSPeriodicInterval">75</int>
-																	<object class="NSMenuItem" key="NSMenuItem" id="933741359">
-																		<reference key="NSMenu" ref="351537137"/>
-																		<string key="NSTitle">Tabs</string>
-																		<string key="NSKeyEquiv"/>
-																		<int key="NSKeyEquivModMask">1048576</int>
-																		<int key="NSMnemonicLoc">2147483647</int>
-																		<int key="NSState">1</int>
-																		<reference key="NSOnImage" ref="123016255"/>
-																		<reference key="NSMixedImage" ref="138212614"/>
-																		<string key="NSAction">_popUpItemAction:</string>
-																		<reference key="NSTarget" ref="661204790"/>
-																	</object>
-																	<bool key="NSMenuItemRespectAlignment">YES</bool>
-																	<object class="NSMenu" key="NSMenu" id="351537137">
-																		<string key="NSTitle"/>
-																		<array class="NSMutableArray" key="NSMenuItems">
-																			<reference ref="933741359"/>
-																			<object class="NSMenuItem" id="921365143">
-																				<reference key="NSMenu" ref="351537137"/>
-																				<string key="NSTitle">Tree</string>
-																				<string key="NSKeyEquiv"/>
-																				<int key="NSKeyEquivModMask">1048576</int>
-																				<int key="NSMnemonicLoc">2147483647</int>
-																				<reference key="NSOnImage" ref="123016255"/>
-																				<reference key="NSMixedImage" ref="138212614"/>
-																				<string key="NSAction">_popUpItemAction:</string>
-																				<reference key="NSTarget" ref="661204790"/>
-																			</object>
-																		</array>
-																	</object>
-																	<int key="NSPreferredEdge">3</int>
-																	<bool key="NSUsesItemFromMenu">YES</bool>
-																	<bool key="NSAltersState">YES</bool>
-																	<int key="NSArrowPosition">1</int>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSButton" id="309106554">
-																<reference key="NSNextResponder" ref="820917927"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{29, 302}, {382, 19}}</string>
-																<reference key="NSSuperview" ref="820917927"/>
-																<reference key="NSNextKeyView" ref="299610555"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSButtonCell" key="NSCell" id="210024465">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">131072</int>
-																	<string key="NSContents">Open a new tab when you receive a private message</string>
-																	<reference key="NSSupport" ref="867044200"/>
-																	<reference key="NSControlView" ref="309106554"/>
-																	<int key="NSButtonFlags">1211912448</int>
-																	<int key="NSButtonFlags2">2</int>
-																	<reference key="NSNormalImage" ref="557231633"/>
-																	<reference key="NSAlternateImage" ref="152492997"/>
-																	<string key="NSAlternateContents"/>
-																	<string key="NSKeyEquivalent"/>
-																	<int key="NSPeriodicDelay">200</int>
-																	<int key="NSPeriodicInterval">25</int>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSTextField" id="1018209368">
-																<reference key="NSNextResponder" ref="820917927"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{4, 210}, {162, 14}}</string>
-																<reference key="NSSuperview" ref="820917927"/>
-																<reference key="NSNextKeyView" ref="100869595"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSTextFieldCell" key="NSCell" id="215960604">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">71303168</int>
-																	<string key="NSContents">Show channel switcher at:</string>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="1018209368"/>
-																	<reference key="NSBackgroundColor" ref="1007130360"/>
-																	<reference key="NSTextColor" ref="725989266"/>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSTextField" id="220142712">
-																<reference key="NSNextResponder" ref="820917927"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{4, 366}, {162, 17}}</string>
-																<reference key="NSSuperview" ref="820917927"/>
-																<reference key="NSNextKeyView" ref="317580382"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSTextFieldCell" key="NSCell" id="137863314">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">71303168</int>
-																	<string key="NSContents">Switcher type:</string>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="220142712"/>
-																	<reference key="NSBackgroundColor" ref="1007130360"/>
-																	<reference key="NSTextColor" ref="725989266"/>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSTextField" id="1005457499">
-																<reference key="NSNextResponder" ref="820917927"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{4, 184}, {162, 17}}</string>
-																<reference key="NSSuperview" ref="820917927"/>
-																<reference key="NSNextKeyView" ref="449540546"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSTextFieldCell" key="NSCell" id="987151587">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">71303168</int>
-																	<string key="NSContents">Shorten tab labels to:</string>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="1005457499"/>
-																	<reference key="NSBackgroundColor" ref="1007130360"/>
-																	<reference key="NSTextColor" ref="725989266"/>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSButton" id="647588713">
-																<reference key="NSNextResponder" ref="820917927"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{29, 344}, {382, 19}}</string>
-																<reference key="NSSuperview" ref="820917927"/>
-																<reference key="NSNextKeyView" ref="446924427"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSButtonCell" key="NSCell" id="284031237">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">131072</int>
-																	<string key="NSContents">Open an extra tab for server messages</string>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="647588713"/>
-																	<int key="NSButtonFlags">1211912448</int>
-																	<int key="NSButtonFlags2">2</int>
-																	<reference key="NSNormalImage" ref="557231633"/>
-																	<reference key="NSAlternateImage" ref="152492997"/>
-																	<string key="NSAlternateContents"/>
-																	<string key="NSKeyEquivalent"/>
-																	<int key="NSPeriodicDelay">200</int>
-																	<int key="NSPeriodicInterval">25</int>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSButton" id="446924427">
-																<reference key="NSNextResponder" ref="820917927"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{29, 323}, {382, 19}}</string>
-																<reference key="NSSuperview" ref="820917927"/>
-																<reference key="NSNextKeyView" ref="309106554"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSButtonCell" key="NSCell" id="702610801">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">131072</int>
-																	<string key="NSContents">Open an extra tab for server notices</string>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="446924427"/>
-																	<int key="NSButtonFlags">1211912448</int>
-																	<int key="NSButtonFlags2">2</int>
-																	<reference key="NSNormalImage" ref="557231633"/>
-																	<reference key="NSAlternateImage" ref="152492997"/>
-																	<string key="NSAlternateContents"/>
-																	<string key="NSKeyEquivalent"/>
-																	<int key="NSPeriodicDelay">200</int>
-																	<int key="NSPeriodicInterval">25</int>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSButton" id="787268415">
-																<reference key="NSNextResponder" ref="820917927"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{29, 281}, {384, 19}}</string>
-																<reference key="NSSuperview" ref="820917927"/>
-																<reference key="NSNextKeyView" ref="118189423"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSButtonCell" key="NSCell" id="561992552">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">131072</int>
-																	<string key="NSContents">Pop new tabs to front</string>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="787268415"/>
-																	<int key="NSButtonFlags">1211912448</int>
-																	<int key="NSButtonFlags2">2</int>
-																	<reference key="NSNormalImage" ref="557231633"/>
-																	<reference key="NSAlternateImage" ref="152492997"/>
-																	<string key="NSAlternateContents"/>
-																	<string key="NSKeyEquivalent"/>
-																	<int key="NSPeriodicDelay">200</int>
-																	<int key="NSPeriodicInterval">25</int>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSButton" id="118189423">
-																<reference key="NSNextResponder" ref="820917927"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{29, 260}, {382, 19}}</string>
-																<reference key="NSSuperview" ref="820917927"/>
-																<reference key="NSNextKeyView" ref="237037613"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSButtonCell" key="NSCell" id="642003061">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">131072</int>
-																	<string key="NSContents">Hide "close" buttons on tabs</string>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="118189423"/>
-																	<int key="NSButtonFlags">1211912448</int>
-																	<int key="NSButtonFlags2">2</int>
-																	<reference key="NSNormalImage" ref="557231633"/>
-																	<reference key="NSAlternateImage" ref="152492997"/>
-																	<string key="NSAlternateContents"/>
-																	<string key="NSKeyEquivalent"/>
-																	<int key="NSPeriodicDelay">200</int>
-																	<int key="NSPeriodicInterval">25</int>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSButton" id="237037613">
-																<reference key="NSNextResponder" ref="820917927"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{29, 239}, {382, 19}}</string>
-																<reference key="NSSuperview" ref="820917927"/>
-																<reference key="NSNextKeyView"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSButtonCell" key="NSCell" id="867671735">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">131072</int>
-																	<string key="NSContents">Smaller text</string>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="237037613"/>
-																	<int key="NSButtonFlags">1211912448</int>
-																	<int key="NSButtonFlags2">2</int>
-																	<reference key="NSNormalImage" ref="557231633"/>
-																	<reference key="NSAlternateImage" ref="152492997"/>
-																	<string key="NSAlternateContents"/>
-																	<string key="NSKeyEquivalent"/>
-																	<int key="NSPeriodicDelay">200</int>
-																	<int key="NSPeriodicInterval">25</int>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSTextField" id="73004003">
-																<reference key="NSNextResponder" ref="820917927"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{22, 149}, {410, 17}}</string>
-																<reference key="NSSuperview" ref="820917927"/>
-																<reference key="NSNextKeyView" ref="1055300200"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSTextFieldCell" key="NSCell" id="220904047">
-																	<int key="NSCellFlags">68157504</int>
-																	<int key="NSCellFlags2">272630784</int>
-																	<string key="NSContents">Tabs or Windows</string>
-																	<reference key="NSSupport" ref="60143749"/>
-																	<reference key="NSControlView" ref="73004003"/>
-																	<reference key="NSBackgroundColor" ref="1007130360"/>
-																	<reference key="NSTextColor" ref="725989266"/>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSTextField" id="449540546">
-																<reference key="NSNextResponder" ref="820917927"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{171, 183}, {100, 19}}</string>
-																<reference key="NSSuperview" ref="820917927"/>
-																<reference key="NSNextKeyView" ref="73004003"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSTextFieldCell" key="NSCell" id="254983759">
-																	<int key="NSCellFlags">-1804599231</int>
-																	<int key="NSCellFlags2">272761856</int>
-																	<string key="NSContents"/>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="449540546"/>
-																	<bool key="NSDrawsBackground">YES</bool>
-																	<reference key="NSBackgroundColor" ref="265355499"/>
-																	<reference key="NSTextColor" ref="328927124"/>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSButton" id="299610555">
-																<reference key="NSNextResponder" ref="820917927"/>
-																<int key="NSvFlags">-2147483380</int>
-																<string key="NSFrame">{{29, 291}, {394, 19}}</string>
-																<reference key="NSSuperview" ref="820917927"/>
-																<reference key="NSNextKeyView" ref="787268415"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSButtonCell" key="NSCell" id="309129550">
-																	<int key="NSCellFlags">603979776</int>
-																	<int key="NSCellFlags2">131072</int>
-																	<string key="NSContents">Sort tabs in alphabetical order</string>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="299610555"/>
-																	<int key="NSButtonFlags">1211912448</int>
-																	<int key="NSButtonFlags2">2</int>
-																	<reference key="NSNormalImage" ref="557231633"/>
-																	<reference key="NSAlternateImage" ref="152492997"/>
-																	<string key="NSAlternateContents"/>
-																	<string key="NSKeyEquivalent"/>
-																	<int key="NSPeriodicDelay">200</int>
-																	<int key="NSPeriodicInterval">25</int>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-														</array>
-														<string key="NSFrameSize">{449, 406}</string>
-														<reference key="NSNextKeyView" ref="220142712"/>
-													</object>
-													<reference key="NSColor" ref="1007130360"/>
-													<reference key="NSTabView" ref="1053574686"/>
-												</object>
-												<object class="NSTabViewItem" id="1041246667">
-													<object class="NSView" key="NSView" id="432098287">
-														<nil key="NSNextResponder"/>
-														<int key="NSvFlags">256</int>
-														<array class="NSMutableArray" key="NSSubviews">
-															<object class="NSButton" id="235267684">
-																<reference key="NSNextResponder" ref="432098287"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{19, 357}, {412, 19}}</string>
-																<reference key="NSSuperview" ref="432098287"/>
-																<reference key="NSNextKeyView" ref="293871888"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSButtonCell" key="NSCell" id="546879026">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">131072</int>
-																	<string key="NSContents">Show channel mode buttons</string>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="235267684"/>
-																	<int key="NSButtonFlags">1211912448</int>
-																	<int key="NSButtonFlags2">2</int>
-																	<reference key="NSNormalImage" ref="557231633"/>
-																	<reference key="NSAlternateImage" ref="152492997"/>
-																	<string key="NSAlternateContents"/>
-																	<string key="NSKeyEquivalent"/>
-																	<int key="NSPeriodicDelay">200</int>
-																	<int key="NSPeriodicInterval">25</int>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSTextField" id="616293540">
-																<reference key="NSNextResponder" ref="432098287"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{17, 317}, {123, 16}}</string>
-																<reference key="NSSuperview" ref="432098287"/>
-																<reference key="NSNextKeyView" ref="179272392"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSTextFieldCell" key="NSCell" id="334746212">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">71303168</int>
-																	<string key="NSContents">Default character set:</string>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="616293540"/>
-																	<reference key="NSBackgroundColor" ref="1007130360"/>
-																	<reference key="NSTextColor" ref="725989266"/>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSTextField" id="179272392">
-																<reference key="NSNextResponder" ref="432098287"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{145, 315}, {101, 19}}</string>
-																<reference key="NSSuperview" ref="432098287"/>
-																<reference key="NSNextKeyView" ref="533408090"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSTextFieldCell" key="NSCell" id="552807489">
-																	<int key="NSCellFlags">-1804599231</int>
-																	<int key="NSCellFlags2">4195328</int>
-																	<string key="NSContents"/>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="179272392"/>
-																	<bool key="NSDrawsBackground">YES</bool>
-																	<reference key="NSBackgroundColor" ref="265355499"/>
-																	<reference key="NSTextColor" ref="328927124"/>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSBox" id="293871888">
-																<reference key="NSNextResponder" ref="432098287"/>
-																<int key="NSvFlags">266</int>
-																<string key="NSFrame">{{12, 340}, {425, 5}}</string>
-																<reference key="NSSuperview" ref="432098287"/>
-																<reference key="NSNextKeyView" ref="616293540"/>
-																<string key="NSOffsets">{0, 0}</string>
-																<object class="NSTextFieldCell" key="NSTitleCell">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">0</int>
-																	<string key="NSContents">Box</string>
-																	<reference key="NSSupport" ref="218849127"/>
-																	<reference key="NSBackgroundColor" ref="265355499"/>
-																	<object class="NSColor" key="NSTextColor">
-																		<int key="NSColorSpace">3</int>
-																		<bytes key="NSWhite">MCAwLjgwMDAwMDAxMTkAA</bytes>
-																	</object>
-																</object>
-																<int key="NSBorderType">3</int>
-																<int key="NSBoxType">2</int>
-																<int key="NSTitlePosition">0</int>
-																<bool key="NSTransparent">NO</bool>
-															</object>
-															<object class="NSTextField" id="533408090">
-																<reference key="NSNextResponder" ref="432098287"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{251, 318}, {232, 14}}</string>
-																<reference key="NSSuperview" ref="432098287"/>
-																<reference key="NSNextKeyView" ref="697368484"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSTextFieldCell" key="NSCell" id="406689511">
-																	<int key="NSCellFlags">68157504</int>
-																	<int key="NSCellFlags2">272761856</int>
-																	<string key="NSContents">(Change takes effect at next launch)</string>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="533408090"/>
-																	<reference key="NSBackgroundColor" ref="1007130360"/>
-																	<reference key="NSTextColor" ref="725989266"/>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSTextField" id="50263017">
-																<reference key="NSNextResponder" ref="432098287"/>
-																<int key="NSvFlags">266</int>
-																<string key="NSFrame">{{209, 255}, {220, 19}}</string>
-																<reference key="NSSuperview" ref="432098287"/>
-																<reference key="NSNextKeyView" ref="883100964"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSTextFieldCell" key="NSCell" id="629888737">
-																	<int key="NSCellFlags">-1804599231</int>
-																	<int key="NSCellFlags2">4195328</int>
-																	<string key="NSContents"/>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="50263017"/>
-																	<bool key="NSDrawsBackground">YES</bool>
-																	<reference key="NSBackgroundColor" ref="265355499"/>
-																	<reference key="NSTextColor" ref="328927124"/>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSTextField" id="584056154">
-																<reference key="NSNextResponder" ref="432098287"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{29, 257}, {175, 14}}</string>
-																<reference key="NSSuperview" ref="432098287"/>
-																<reference key="NSNextKeyView" ref="50263017"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSTextFieldCell" key="NSCell" id="1062960645">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">71303168</int>
-																	<string key="NSContents">URL link command:</string>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="584056154"/>
-																	<reference key="NSBackgroundColor" ref="1007130360"/>
-																	<reference key="NSTextColor" ref="725989266"/>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSTextField" id="627093559">
-																<reference key="NSNextResponder" ref="432098287"/>
-																<int key="NSvFlags">266</int>
-																<string key="NSFrame">{{209, 226}, {220, 19}}</string>
-																<reference key="NSSuperview" ref="432098287"/>
-																<reference key="NSNextKeyView" ref="1051657128"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSTextFieldCell" key="NSCell" id="861224543">
-																	<int key="NSCellFlags">-1804599231</int>
-																	<int key="NSCellFlags2">4195328</int>
-																	<string key="NSContents"/>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="627093559"/>
-																	<bool key="NSDrawsBackground">YES</bool>
-																	<reference key="NSBackgroundColor" ref="265355499"/>
-																	<reference key="NSTextColor" ref="328927124"/>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSTextField" id="883100964">
-																<reference key="NSNextResponder" ref="432098287"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{31, 228}, {175, 14}}</string>
-																<reference key="NSSuperview" ref="432098287"/>
-																<reference key="NSNextKeyView" ref="627093559"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSTextFieldCell" key="NSCell" id="986304381">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">71303168</int>
-																	<string key="NSContents">Nick link command:</string>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="883100964"/>
-																	<reference key="NSBackgroundColor" ref="1007130360"/>
-																	<reference key="NSTextColor" ref="725989266"/>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSTextField" id="388795386">
-																<reference key="NSNextResponder" ref="432098287"/>
-																<int key="NSvFlags">266</int>
-																<string key="NSFrame">{{209, 197}, {220, 19}}</string>
-																<reference key="NSSuperview" ref="432098287"/>
-																<reference key="NSNextKeyView" ref="1053574686"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSTextFieldCell" key="NSCell" id="629136392">
-																	<int key="NSCellFlags">-1804599231</int>
-																	<int key="NSCellFlags2">4195328</int>
-																	<string key="NSContents"/>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="388795386"/>
-																	<bool key="NSDrawsBackground">YES</bool>
-																	<reference key="NSBackgroundColor" ref="265355499"/>
-																	<reference key="NSTextColor" ref="328927124"/>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSTextField" id="1051657128">
-																<reference key="NSNextResponder" ref="432098287"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{19, 199}, {185, 14}}</string>
-																<reference key="NSSuperview" ref="432098287"/>
-																<reference key="NSNextKeyView" ref="388795386"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSTextFieldCell" key="NSCell" id="208523081">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">71303168</int>
-																	<string key="NSContents">Channel link command:</string>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="1051657128"/>
-																	<reference key="NSBackgroundColor" ref="1007130360"/>
-																	<reference key="NSTextColor" ref="725989266"/>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSTextField" id="697368484">
-																<reference key="NSNextResponder" ref="432098287"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{17, 279}, {415, 17}}</string>
-																<reference key="NSSuperview" ref="432098287"/>
-																<reference key="NSNextKeyView" ref="584056154"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSTextFieldCell" key="NSCell" id="633881091">
-																	<int key="NSCellFlags">68157504</int>
-																	<int key="NSCellFlags2">272630784</int>
-																	<string key="NSContents">Command</string>
-																	<reference key="NSSupport" ref="60143749"/>
-																	<reference key="NSControlView" ref="697368484"/>
-																	<reference key="NSBackgroundColor" ref="1007130360"/>
-																	<reference key="NSTextColor" ref="725989266"/>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-														</array>
-														<string key="NSFrameSize">{449, 406}</string>
-														<reference key="NSNextKeyView" ref="235267684"/>
-													</object>
-													<reference key="NSColor" ref="1007130360"/>
-													<reference key="NSTabView" ref="1053574686"/>
-												</object>
-												<object class="NSTabViewItem" id="625907395">
-													<object class="NSView" key="NSView" id="402415888">
-														<nil key="NSNextResponder"/>
-														<int key="NSvFlags">256</int>
-														<array class="NSMutableArray" key="NSSubviews">
-															<object class="NSTextField" id="48224885">
-																<reference key="NSNextResponder" ref="402415888"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{14, 368}, {205, 18}}</string>
-																<reference key="NSSuperview" ref="402415888"/>
-																<reference key="NSNextKeyView" ref="155506199"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSTextFieldCell" key="NSCell" id="917059312">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">4194304</int>
-																	<string key="NSContents">Text Colors</string>
-																	<object class="NSFont" key="NSSupport" id="29">
-																		<string key="NSName">LucidaGrande-Bold</string>
-																		<double key="NSSize">12</double>
-																		<int key="NSfFlags">16</int>
-																	</object>
-																	<reference key="NSControlView" ref="48224885"/>
-																	<reference key="NSBackgroundColor" ref="1007130360"/>
-																	<reference key="NSTextColor" ref="725989266"/>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSTextField" id="155506199">
-																<reference key="NSNextResponder" ref="402415888"/>
-																<int key="NSvFlags">269</int>
-																<string key="NSFrame">{{106, 347}, {20, 13}}</string>
-																<reference key="NSSuperview" ref="402415888"/>
-																<reference key="NSNextKeyView" ref="140668850"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSTextFieldCell" key="NSCell" id="632146717">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">138412032</int>
-																	<string key="NSContents">0</string>
-																	<object class="NSFont" key="NSSupport" id="309389375">
-																		<string key="NSName">LucidaGrande</string>
-																		<double key="NSSize">10</double>
-																		<int key="NSfFlags">2843</int>
-																	</object>
-																	<reference key="NSControlView" ref="155506199"/>
-																	<reference key="NSBackgroundColor" ref="1007130360"/>
-																	<reference key="NSTextColor" ref="725989266"/>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSTextField" id="140668850">
-																<reference key="NSNextResponder" ref="402415888"/>
-																<int key="NSvFlags">269</int>
-																<string key="NSFrame">{{127, 347}, {20, 13}}</string>
-																<reference key="NSSuperview" ref="402415888"/>
-																<reference key="NSNextKeyView" ref="103645729"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSTextFieldCell" key="NSCell" id="266134953">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">138412032</int>
-																	<string key="NSContents">1</string>
-																	<reference key="NSSupport" ref="309389375"/>
-																	<reference key="NSControlView" ref="140668850"/>
-																	<reference key="NSBackgroundColor" ref="1007130360"/>
-																	<reference key="NSTextColor" ref="725989266"/>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSTextField" id="103645729">
-																<reference key="NSNextResponder" ref="402415888"/>
-																<int key="NSvFlags">269</int>
-																<string key="NSFrame">{{148, 347}, {20, 13}}</string>
-																<reference key="NSSuperview" ref="402415888"/>
-																<reference key="NSNextKeyView" ref="684434690"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSTextFieldCell" key="NSCell" id="324254028">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">138412032</int>
-																	<string key="NSContents">2</string>
-																	<reference key="NSSupport" ref="309389375"/>
-																	<reference key="NSControlView" ref="103645729"/>
-																	<reference key="NSBackgroundColor" ref="1007130360"/>
-																	<reference key="NSTextColor" ref="725989266"/>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSTextField" id="684434690">
-																<reference key="NSNextResponder" ref="402415888"/>
-																<int key="NSvFlags">269</int>
-																<string key="NSFrame">{{169, 347}, {20, 13}}</string>
-																<reference key="NSSuperview" ref="402415888"/>
-																<reference key="NSNextKeyView" ref="310238798"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSTextFieldCell" key="NSCell" id="752262986">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">138412032</int>
-																	<string key="NSContents">3</string>
-																	<reference key="NSSupport" ref="309389375"/>
-																	<reference key="NSControlView" ref="684434690"/>
-																	<reference key="NSBackgroundColor" ref="1007130360"/>
-																	<reference key="NSTextColor" ref="725989266"/>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSTextField" id="310238798">
-																<reference key="NSNextResponder" ref="402415888"/>
-																<int key="NSvFlags">269</int>
-																<string key="NSFrame">{{190, 347}, {20, 13}}</string>
-																<reference key="NSSuperview" ref="402415888"/>
-																<reference key="NSNextKeyView" ref="500715027"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSTextFieldCell" key="NSCell" id="930614570">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">138412032</int>
-																	<string key="NSContents">4</string>
-																	<reference key="NSSupport" ref="309389375"/>
-																	<reference key="NSControlView" ref="310238798"/>
-																	<reference key="NSBackgroundColor" ref="1007130360"/>
-																	<reference key="NSTextColor" ref="725989266"/>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSTextField" id="500715027">
-																<reference key="NSNextResponder" ref="402415888"/>
-																<int key="NSvFlags">269</int>
-																<string key="NSFrame">{{211, 347}, {20, 13}}</string>
-																<reference key="NSSuperview" ref="402415888"/>
-																<reference key="NSNextKeyView" ref="68055949"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSTextFieldCell" key="NSCell" id="384183697">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">138412032</int>
-																	<string key="NSContents">5</string>
-																	<reference key="NSSupport" ref="309389375"/>
-																	<reference key="NSControlView" ref="500715027"/>
-																	<reference key="NSBackgroundColor" ref="1007130360"/>
-																	<reference key="NSTextColor" ref="725989266"/>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSTextField" id="68055949">
-																<reference key="NSNextResponder" ref="402415888"/>
-																<int key="NSvFlags">269</int>
-																<string key="NSFrame">{{232, 347}, {20, 13}}</string>
-																<reference key="NSSuperview" ref="402415888"/>
-																<reference key="NSNextKeyView" ref="411107394"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSTextFieldCell" key="NSCell" id="716683096">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">138412032</int>
-																	<string key="NSContents">6</string>
-																	<reference key="NSSupport" ref="309389375"/>
-																	<reference key="NSControlView" ref="68055949"/>
-																	<reference key="NSBackgroundColor" ref="1007130360"/>
-																	<reference key="NSTextColor" ref="725989266"/>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSTextField" id="411107394">
-																<reference key="NSNextResponder" ref="402415888"/>
-																<int key="NSvFlags">269</int>
-																<string key="NSFrame">{{253, 347}, {20, 13}}</string>
-																<reference key="NSSuperview" ref="402415888"/>
-																<reference key="NSNextKeyView" ref="425465266"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSTextFieldCell" key="NSCell" id="1014148869">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">138412032</int>
-																	<string key="NSContents">7</string>
-																	<reference key="NSSupport" ref="309389375"/>
-																	<reference key="NSControlView" ref="411107394"/>
-																	<reference key="NSBackgroundColor" ref="1007130360"/>
-																	<reference key="NSTextColor" ref="725989266"/>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSTextField" id="425465266">
-																<reference key="NSNextResponder" ref="402415888"/>
-																<int key="NSvFlags">269</int>
-																<string key="NSFrame">{{274, 347}, {20, 13}}</string>
-																<reference key="NSSuperview" ref="402415888"/>
-																<reference key="NSNextKeyView" ref="648433288"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSTextFieldCell" key="NSCell" id="68071633">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">138412032</int>
-																	<string key="NSContents">8</string>
-																	<reference key="NSSupport" ref="309389375"/>
-																	<reference key="NSControlView" ref="425465266"/>
-																	<reference key="NSBackgroundColor" ref="1007130360"/>
-																	<reference key="NSTextColor" ref="725989266"/>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSTextField" id="648433288">
-																<reference key="NSNextResponder" ref="402415888"/>
-																<int key="NSvFlags">269</int>
-																<string key="NSFrame">{{295, 347}, {20, 13}}</string>
-																<reference key="NSSuperview" ref="402415888"/>
-																<reference key="NSNextKeyView" ref="650187603"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSTextFieldCell" key="NSCell" id="235564002">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">138412032</int>
-																	<string key="NSContents">9</string>
-																	<reference key="NSSupport" ref="309389375"/>
-																	<reference key="NSControlView" ref="648433288"/>
-																	<reference key="NSBackgroundColor" ref="1007130360"/>
-																	<reference key="NSTextColor" ref="725989266"/>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSTextField" id="650187603">
-																<reference key="NSNextResponder" ref="402415888"/>
-																<int key="NSvFlags">269</int>
-																<string key="NSFrame">{{315, 347}, {22, 13}}</string>
-																<reference key="NSSuperview" ref="402415888"/>
-																<reference key="NSNextKeyView" ref="369930811"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSTextFieldCell" key="NSCell" id="719155945">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">138412032</int>
-																	<string key="NSContents">10</string>
-																	<reference key="NSSupport" ref="309389375"/>
-																	<reference key="NSControlView" ref="650187603"/>
-																	<reference key="NSBackgroundColor" ref="1007130360"/>
-																	<reference key="NSTextColor" ref="725989266"/>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSTextField" id="369930811">
-																<reference key="NSNextResponder" ref="402415888"/>
-																<int key="NSvFlags">269</int>
-																<string key="NSFrame">{{336, 347}, {22, 13}}</string>
-																<reference key="NSSuperview" ref="402415888"/>
-																<reference key="NSNextKeyView" ref="222278178"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSTextFieldCell" key="NSCell" id="418582562">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">138412032</int>
-																	<string key="NSContents">11</string>
-																	<reference key="NSSupport" ref="309389375"/>
-																	<reference key="NSControlView" ref="369930811"/>
-																	<reference key="NSBackgroundColor" ref="1007130360"/>
-																	<reference key="NSTextColor" ref="725989266"/>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSTextField" id="222278178">
-																<reference key="NSNextResponder" ref="402415888"/>
-																<int key="NSvFlags">269</int>
-																<string key="NSFrame">{{357, 347}, {22, 13}}</string>
-																<reference key="NSSuperview" ref="402415888"/>
-																<reference key="NSNextKeyView" ref="23368208"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSTextFieldCell" key="NSCell" id="485807180">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">138412032</int>
-																	<string key="NSContents">12</string>
-																	<reference key="NSSupport" ref="309389375"/>
-																	<reference key="NSControlView" ref="222278178"/>
-																	<reference key="NSBackgroundColor" ref="1007130360"/>
-																	<reference key="NSTextColor" ref="725989266"/>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSTextField" id="23368208">
-																<reference key="NSNextResponder" ref="402415888"/>
-																<int key="NSvFlags">269</int>
-																<string key="NSFrame">{{378, 347}, {22, 13}}</string>
-																<reference key="NSSuperview" ref="402415888"/>
-																<reference key="NSNextKeyView" ref="83455403"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSTextFieldCell" key="NSCell" id="349282212">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">138412032</int>
-																	<string key="NSContents">13</string>
-																	<reference key="NSSupport" ref="309389375"/>
-																	<reference key="NSControlView" ref="23368208"/>
-																	<reference key="NSBackgroundColor" ref="1007130360"/>
-																	<reference key="NSTextColor" ref="725989266"/>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSTextField" id="83455403">
-																<reference key="NSNextResponder" ref="402415888"/>
-																<int key="NSvFlags">269</int>
-																<string key="NSFrame">{{399, 347}, {22, 13}}</string>
-																<reference key="NSSuperview" ref="402415888"/>
-																<reference key="NSNextKeyView" ref="340464604"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSTextFieldCell" key="NSCell" id="674571607">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">138412032</int>
-																	<string key="NSContents">14</string>
-																	<reference key="NSSupport" ref="309389375"/>
-																	<reference key="NSControlView" ref="83455403"/>
-																	<reference key="NSBackgroundColor" ref="1007130360"/>
-																	<reference key="NSTextColor" ref="725989266"/>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSTextField" id="340464604">
-																<reference key="NSNextResponder" ref="402415888"/>
-																<int key="NSvFlags">269</int>
-																<string key="NSFrame">{{420, 347}, {22, 13}}</string>
-																<reference key="NSSuperview" ref="402415888"/>
-																<reference key="NSNextKeyView" ref="957933488"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSTextFieldCell" key="NSCell" id="445066095">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">138412032</int>
-																	<string key="NSContents">15</string>
-																	<reference key="NSSupport" ref="309389375"/>
-																	<reference key="NSControlView" ref="340464604"/>
-																	<reference key="NSBackgroundColor" ref="1007130360"/>
-																	<reference key="NSTextColor" ref="725989266"/>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSTextField" id="957933488">
-																<reference key="NSNextResponder" ref="402415888"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{14, 327}, {89, 17}}</string>
-																<reference key="NSSuperview" ref="402415888"/>
-																<reference key="NSNextKeyView" ref="233349765"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSTextFieldCell" key="NSCell" id="558234484">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">71303168</int>
-																	<string key="NSContents">mIRC colors:</string>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="957933488"/>
-																	<reference key="NSBackgroundColor" ref="1007130360"/>
-																	<reference key="NSTextColor" ref="725989266"/>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSColorWell" id="233349765">
-																<reference key="NSNextResponder" ref="402415888"/>
-																<int key="NSvFlags">269</int>
-																<set class="NSMutableSet" key="NSDragTypes">
-																	<object class="NSMutableString">
-																		<characters key="NS.bytes">NSColor pasteboard type</characters>
-																	</object>
-																</set>
-																<string key="NSFrame">{{106, 327}, {20, 20}}</string>
-																<reference key="NSSuperview" ref="402415888"/>
-																<reference key="NSNextKeyView" ref="1038163933"/>
-																<bool key="NSEnabled">YES</bool>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																<bool key="NSIsBordered">YES</bool>
-																<object class="NSColor" key="NSColor">
-																	<int key="NSColorSpace">1</int>
-																	<bytes key="NSRGB">MC4wNTgxMzA0OTg5OCAwLjA1NTU0MTg5OTA2IDEAA</bytes>
-																</object>
-															</object>
-															<object class="NSColorWell" id="1038163933">
-																<reference key="NSNextResponder" ref="402415888"/>
-																<int key="NSvFlags">269</int>
-																<set class="NSMutableSet" key="NSDragTypes">
-																	<object class="NSMutableString">
-																		<characters key="NS.bytes">NSColor pasteboard type</characters>
-																	</object>
-																</set>
-																<string key="NSFrame">{{127, 327}, {20, 20}}</string>
-																<reference key="NSSuperview" ref="402415888"/>
-																<reference key="NSNextKeyView" ref="824992908"/>
-																<int key="NSTag">1</int>
-																<bool key="NSEnabled">YES</bool>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																<bool key="NSIsBordered">YES</bool>
-																<object class="NSColor" key="NSColor">
-																	<int key="NSColorSpace">1</int>
-																	<bytes key="NSRGB">MC4wNTgxMzA0OTg5OCAwLjA1NTU0MTg5OTA2IDEAA</bytes>
-																</object>
-															</object>
-															<object class="NSColorWell" id="824992908">
-																<reference key="NSNextResponder" ref="402415888"/>
-																<int key="NSvFlags">269</int>
-																<set class="NSMutableSet" key="NSDragTypes">
-																	<object class="NSMutableString">
-																		<characters key="NS.bytes">NSColor pasteboard type</characters>
-																	</object>
-																</set>
-																<string key="NSFrame">{{148, 327}, {20, 20}}</string>
-																<reference key="NSSuperview" ref="402415888"/>
-																<reference key="NSNextKeyView" ref="511299136"/>
-																<int key="NSTag">2</int>
-																<bool key="NSEnabled">YES</bool>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																<bool key="NSIsBordered">YES</bool>
-																<object class="NSColor" key="NSColor">
-																	<int key="NSColorSpace">1</int>
-																	<bytes key="NSRGB">MC4wNTgxMzA0OTg5OCAwLjA1NTU0MTg5OTA2IDEAA</bytes>
-																</object>
-															</object>
-															<object class="NSColorWell" id="511299136">
-																<reference key="NSNextResponder" ref="402415888"/>
-																<int key="NSvFlags">269</int>
-																<set class="NSMutableSet" key="NSDragTypes">
-																	<object class="NSMutableString">
-																		<characters key="NS.bytes">NSColor pasteboard type</characters>
-																	</object>
-																</set>
-																<string key="NSFrame">{{169, 327}, {20, 20}}</string>
-																<reference key="NSSuperview" ref="402415888"/>
-																<reference key="NSNextKeyView" ref="271561416"/>
-																<int key="NSTag">3</int>
-																<bool key="NSEnabled">YES</bool>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																<bool key="NSIsBordered">YES</bool>
-																<object class="NSColor" key="NSColor">
-																	<int key="NSColorSpace">1</int>
-																	<bytes key="NSRGB">MC4wNTgxMzA0OTg5OCAwLjA1NTU0MTg5OTA2IDEAA</bytes>
-																</object>
-															</object>
-															<object class="NSColorWell" id="271561416">
-																<reference key="NSNextResponder" ref="402415888"/>
-																<int key="NSvFlags">269</int>
-																<set class="NSMutableSet" key="NSDragTypes">
-																	<object class="NSMutableString">
-																		<characters key="NS.bytes">NSColor pasteboard type</characters>
-																	</object>
-																</set>
-																<string key="NSFrame">{{190, 327}, {20, 20}}</string>
-																<reference key="NSSuperview" ref="402415888"/>
-																<reference key="NSNextKeyView" ref="727596136"/>
-																<int key="NSTag">4</int>
-																<bool key="NSEnabled">YES</bool>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																<bool key="NSIsBordered">YES</bool>
-																<object class="NSColor" key="NSColor">
-																	<int key="NSColorSpace">1</int>
-																	<bytes key="NSRGB">MC4wNTgxMzA0OTg5OCAwLjA1NTU0MTg5OTA2IDEAA</bytes>
-																</object>
-															</object>
-															<object class="NSColorWell" id="727596136">
-																<reference key="NSNextResponder" ref="402415888"/>
-																<int key="NSvFlags">269</int>
-																<set class="NSMutableSet" key="NSDragTypes">
-																	<object class="NSMutableString">
-																		<characters key="NS.bytes">NSColor pasteboard type</characters>
-																	</object>
-																</set>
-																<string key="NSFrame">{{211, 327}, {20, 20}}</string>
-																<reference key="NSSuperview" ref="402415888"/>
-																<reference key="NSNextKeyView" ref="163181294"/>
-																<int key="NSTag">5</int>
-																<bool key="NSEnabled">YES</bool>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																<bool key="NSIsBordered">YES</bool>
-																<object class="NSColor" key="NSColor">
-																	<int key="NSColorSpace">1</int>
-																	<bytes key="NSRGB">MC4wNTgxMzA0OTg5OCAwLjA1NTU0MTg5OTA2IDEAA</bytes>
-																</object>
-															</object>
-															<object class="NSColorWell" id="163181294">
-																<reference key="NSNextResponder" ref="402415888"/>
-																<int key="NSvFlags">269</int>
-																<set class="NSMutableSet" key="NSDragTypes">
-																	<object class="NSMutableString">
-																		<characters key="NS.bytes">NSColor pasteboard type</characters>
-																	</object>
-																</set>
-																<string key="NSFrame">{{232, 327}, {20, 20}}</string>
-																<reference key="NSSuperview" ref="402415888"/>
-																<reference key="NSNextKeyView" ref="772434347"/>
-																<int key="NSTag">6</int>
-																<bool key="NSEnabled">YES</bool>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																<bool key="NSIsBordered">YES</bool>
-																<object class="NSColor" key="NSColor">
-																	<int key="NSColorSpace">1</int>
-																	<bytes key="NSRGB">MC4wNTgxMzA0OTg5OCAwLjA1NTU0MTg5OTA2IDEAA</bytes>
-																</object>
-															</object>
-															<object class="NSColorWell" id="772434347">
-																<reference key="NSNextResponder" ref="402415888"/>
-																<int key="NSvFlags">269</int>
-																<set class="NSMutableSet" key="NSDragTypes">
-																	<object class="NSMutableString">
-																		<characters key="NS.bytes">NSColor pasteboard type</characters>
-																	</object>
-																</set>
-																<string key="NSFrame">{{253, 327}, {20, 20}}</string>
-																<reference key="NSSuperview" ref="402415888"/>
-																<reference key="NSNextKeyView" ref="960025613"/>
-																<int key="NSTag">7</int>
-																<bool key="NSEnabled">YES</bool>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																<bool key="NSIsBordered">YES</bool>
-																<object class="NSColor" key="NSColor">
-																	<int key="NSColorSpace">1</int>
-																	<bytes key="NSRGB">MC4wNTgxMzA0OTg5OCAwLjA1NTU0MTg5OTA2IDEAA</bytes>
-																</object>
-															</object>
-															<object class="NSColorWell" id="960025613">
-																<reference key="NSNextResponder" ref="402415888"/>
-																<int key="NSvFlags">269</int>
-																<set class="NSMutableSet" key="NSDragTypes">
-																	<object class="NSMutableString">
-																		<characters key="NS.bytes">NSColor pasteboard type</characters>
-																	</object>
-																</set>
-																<string key="NSFrame">{{274, 327}, {20, 20}}</string>
-																<reference key="NSSuperview" ref="402415888"/>
-																<reference key="NSNextKeyView" ref="1055210306"/>
-																<int key="NSTag">8</int>
-																<bool key="NSEnabled">YES</bool>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																<bool key="NSIsBordered">YES</bool>
-																<object class="NSColor" key="NSColor">
-																	<int key="NSColorSpace">1</int>
-																	<bytes key="NSRGB">MC4wNTgxMzA0OTg5OCAwLjA1NTU0MTg5OTA2IDEAA</bytes>
-																</object>
-															</object>
-															<object class="NSColorWell" id="1055210306">
-																<reference key="NSNextResponder" ref="402415888"/>
-																<int key="NSvFlags">269</int>
-																<set class="NSMutableSet" key="NSDragTypes">
-																	<object class="NSMutableString">
-																		<characters key="NS.bytes">NSColor pasteboard type</characters>
-																	</object>
-																</set>
-																<string key="NSFrame">{{295, 327}, {20, 20}}</string>
-																<reference key="NSSuperview" ref="402415888"/>
-																<reference key="NSNextKeyView" ref="532978015"/>
-																<int key="NSTag">9</int>
-																<bool key="NSEnabled">YES</bool>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																<bool key="NSIsBordered">YES</bool>
-																<object class="NSColor" key="NSColor">
-																	<int key="NSColorSpace">1</int>
-																	<bytes key="NSRGB">MC4wNTgxMzA0OTg5OCAwLjA1NTU0MTg5OTA2IDEAA</bytes>
-																</object>
-															</object>
-															<object class="NSColorWell" id="532978015">
-																<reference key="NSNextResponder" ref="402415888"/>
-																<int key="NSvFlags">269</int>
-																<set class="NSMutableSet" key="NSDragTypes">
-																	<object class="NSMutableString">
-																		<characters key="NS.bytes">NSColor pasteboard type</characters>
-																	</object>
-																</set>
-																<string key="NSFrame">{{316, 327}, {20, 20}}</string>
-																<reference key="NSSuperview" ref="402415888"/>
-																<reference key="NSNextKeyView" ref="854857905"/>
-																<int key="NSTag">10</int>
-																<bool key="NSEnabled">YES</bool>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																<bool key="NSIsBordered">YES</bool>
-																<object class="NSColor" key="NSColor">
-																	<int key="NSColorSpace">1</int>
-																	<bytes key="NSRGB">MC4wNTgxMzA0OTg5OCAwLjA1NTU0MTg5OTA2IDEAA</bytes>
-																</object>
-															</object>
-															<object class="NSColorWell" id="854857905">
-																<reference key="NSNextResponder" ref="402415888"/>
-																<int key="NSvFlags">269</int>
-																<set class="NSMutableSet" key="NSDragTypes">
-																	<object class="NSMutableString">
-																		<characters key="NS.bytes">NSColor pasteboard type</characters>
-																	</object>
-																</set>
-																<string key="NSFrame">{{337, 327}, {20, 20}}</string>
-																<reference key="NSSuperview" ref="402415888"/>
-																<reference key="NSNextKeyView" ref="161554151"/>
-																<int key="NSTag">11</int>
-																<bool key="NSEnabled">YES</bool>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																<bool key="NSIsBordered">YES</bool>
-																<object class="NSColor" key="NSColor">
-																	<int key="NSColorSpace">1</int>
-																	<bytes key="NSRGB">MC4wNTgxMzA0OTg5OCAwLjA1NTU0MTg5OTA2IDEAA</bytes>
-																</object>
-															</object>
-															<object class="NSColorWell" id="161554151">
-																<reference key="NSNextResponder" ref="402415888"/>
-																<int key="NSvFlags">269</int>
-																<set class="NSMutableSet" key="NSDragTypes">
-																	<object class="NSMutableString">
-																		<characters key="NS.bytes">NSColor pasteboard type</characters>
-																	</object>
-																</set>
-																<string key="NSFrame">{{358, 327}, {20, 20}}</string>
-																<reference key="NSSuperview" ref="402415888"/>
-																<reference key="NSNextKeyView" ref="958081887"/>
-																<int key="NSTag">12</int>
-																<bool key="NSEnabled">YES</bool>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																<bool key="NSIsBordered">YES</bool>
-																<object class="NSColor" key="NSColor">
-																	<int key="NSColorSpace">1</int>
-																	<bytes key="NSRGB">MC4wNTgxMzA0OTg5OCAwLjA1NTU0MTg5OTA2IDEAA</bytes>
-																</object>
-															</object>
-															<object class="NSColorWell" id="958081887">
-																<reference key="NSNextResponder" ref="402415888"/>
-																<int key="NSvFlags">269</int>
-																<set class="NSMutableSet" key="NSDragTypes">
-																	<object class="NSMutableString">
-																		<characters key="NS.bytes">NSColor pasteboard type</characters>
-																	</object>
-																</set>
-																<string key="NSFrame">{{379, 327}, {20, 20}}</string>
-																<reference key="NSSuperview" ref="402415888"/>
-																<reference key="NSNextKeyView" ref="504661049"/>
-																<int key="NSTag">13</int>
-																<bool key="NSEnabled">YES</bool>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																<bool key="NSIsBordered">YES</bool>
-																<object class="NSColor" key="NSColor">
-																	<int key="NSColorSpace">1</int>
-																	<bytes key="NSRGB">MC4wNTgxMzA0OTg5OCAwLjA1NTU0MTg5OTA2IDEAA</bytes>
-																</object>
-															</object>
-															<object class="NSColorWell" id="504661049">
-																<reference key="NSNextResponder" ref="402415888"/>
-																<int key="NSvFlags">269</int>
-																<set class="NSMutableSet" key="NSDragTypes">
-																	<object class="NSMutableString">
-																		<characters key="NS.bytes">NSColor pasteboard type</characters>
-																	</object>
-																</set>
-																<string key="NSFrame">{{400, 327}, {20, 20}}</string>
-																<reference key="NSSuperview" ref="402415888"/>
-																<reference key="NSNextKeyView" ref="748452430"/>
-																<int key="NSTag">14</int>
-																<bool key="NSEnabled">YES</bool>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																<bool key="NSIsBordered">YES</bool>
-																<object class="NSColor" key="NSColor">
-																	<int key="NSColorSpace">1</int>
-																	<bytes key="NSRGB">MC4wNTgxMzA0OTg5OCAwLjA1NTU0MTg5OTA2IDEAA</bytes>
-																</object>
-															</object>
-															<object class="NSColorWell" id="748452430">
-																<reference key="NSNextResponder" ref="402415888"/>
-																<int key="NSvFlags">269</int>
-																<set class="NSMutableSet" key="NSDragTypes">
-																	<object class="NSMutableString">
-																		<characters key="NS.bytes">NSColor pasteboard type</characters>
-																	</object>
-																</set>
-																<string key="NSFrame">{{421, 327}, {20, 20}}</string>
-																<reference key="NSSuperview" ref="402415888"/>
-																<reference key="NSNextKeyView" ref="925310567"/>
-																<int key="NSTag">15</int>
-																<bool key="NSEnabled">YES</bool>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																<bool key="NSIsBordered">YES</bool>
-																<object class="NSColor" key="NSColor">
-																	<int key="NSColorSpace">1</int>
-																	<bytes key="NSRGB">MC4wNTgxMzA0OTg5OCAwLjA1NTU0MTg5OTA2IDEAA</bytes>
-																</object>
-															</object>
-															<object class="NSTextField" id="925310567">
-																<reference key="NSNextResponder" ref="402415888"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{14, 303}, {89, 17}}</string>
-																<reference key="NSSuperview" ref="402415888"/>
-																<reference key="NSNextKeyView" ref="840033143"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSTextFieldCell" key="NSCell" id="373482299">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">71303168</int>
-																	<string key="NSContents">Local colors:</string>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="925310567"/>
-																	<reference key="NSBackgroundColor" ref="1007130360"/>
-																	<reference key="NSTextColor" ref="725989266"/>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSColorWell" id="840033143">
-																<reference key="NSNextResponder" ref="402415888"/>
-																<int key="NSvFlags">269</int>
-																<set class="NSMutableSet" key="NSDragTypes">
-																	<object class="NSMutableString">
-																		<characters key="NS.bytes">NSColor pasteboard type</characters>
-																	</object>
-																</set>
-																<string key="NSFrame">{{106, 301}, {20, 20}}</string>
-																<reference key="NSSuperview" ref="402415888"/>
-																<reference key="NSNextKeyView" ref="208667344"/>
-																<int key="NSTag">16</int>
-																<bool key="NSEnabled">YES</bool>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																<bool key="NSIsBordered">YES</bool>
-																<object class="NSColor" key="NSColor">
-																	<int key="NSColorSpace">1</int>
-																	<bytes key="NSRGB">MC4wNTgxMzA0OTg5OCAwLjA1NTU0MTg5OTA2IDEAA</bytes>
-																</object>
-															</object>
-															<object class="NSColorWell" id="208667344">
-																<reference key="NSNextResponder" ref="402415888"/>
-																<int key="NSvFlags">269</int>
-																<set class="NSMutableSet" key="NSDragTypes">
-																	<object class="NSMutableString">
-																		<characters key="NS.bytes">NSColor pasteboard type</characters>
-																	</object>
-																</set>
-																<string key="NSFrame">{{127, 301}, {20, 20}}</string>
-																<reference key="NSSuperview" ref="402415888"/>
-																<reference key="NSNextKeyView" ref="489144235"/>
-																<int key="NSTag">17</int>
-																<bool key="NSEnabled">YES</bool>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																<bool key="NSIsBordered">YES</bool>
-																<object class="NSColor" key="NSColor">
-																	<int key="NSColorSpace">1</int>
-																	<bytes key="NSRGB">MC4wNTgxMzA0OTg5OCAwLjA1NTU0MTg5OTA2IDEAA</bytes>
-																</object>
-															</object>
-															<object class="NSColorWell" id="489144235">
-																<reference key="NSNextResponder" ref="402415888"/>
-																<int key="NSvFlags">269</int>
-																<set class="NSMutableSet" key="NSDragTypes">
-																	<object class="NSMutableString">
-																		<characters key="NS.bytes">NSColor pasteboard type</characters>
-																	</object>
-																</set>
-																<string key="NSFrame">{{148, 301}, {20, 20}}</string>
-																<reference key="NSSuperview" ref="402415888"/>
-																<reference key="NSNextKeyView" ref="765851134"/>
-																<int key="NSTag">18</int>
-																<bool key="NSEnabled">YES</bool>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																<bool key="NSIsBordered">YES</bool>
-																<object class="NSColor" key="NSColor">
-																	<int key="NSColorSpace">1</int>
-																	<bytes key="NSRGB">MC4wNTgxMzA0OTg5OCAwLjA1NTU0MTg5OTA2IDEAA</bytes>
-																</object>
-															</object>
-															<object class="NSColorWell" id="765851134">
-																<reference key="NSNextResponder" ref="402415888"/>
-																<int key="NSvFlags">269</int>
-																<set class="NSMutableSet" key="NSDragTypes">
-																	<object class="NSMutableString">
-																		<characters key="NS.bytes">NSColor pasteboard type</characters>
-																	</object>
-																</set>
-																<string key="NSFrame">{{169, 301}, {20, 20}}</string>
-																<reference key="NSSuperview" ref="402415888"/>
-																<reference key="NSNextKeyView" ref="1026900652"/>
-																<int key="NSTag">19</int>
-																<bool key="NSEnabled">YES</bool>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																<bool key="NSIsBordered">YES</bool>
-																<object class="NSColor" key="NSColor">
-																	<int key="NSColorSpace">1</int>
-																	<bytes key="NSRGB">MC4wNTgxMzA0OTg5OCAwLjA1NTU0MTg5OTA2IDEAA</bytes>
-																</object>
-															</object>
-															<object class="NSColorWell" id="1026900652">
-																<reference key="NSNextResponder" ref="402415888"/>
-																<int key="NSvFlags">269</int>
-																<set class="NSMutableSet" key="NSDragTypes">
-																	<object class="NSMutableString">
-																		<characters key="NS.bytes">NSColor pasteboard type</characters>
-																	</object>
-																</set>
-																<string key="NSFrame">{{190, 301}, {20, 20}}</string>
-																<reference key="NSSuperview" ref="402415888"/>
-																<reference key="NSNextKeyView" ref="258665417"/>
-																<int key="NSTag">20</int>
-																<bool key="NSEnabled">YES</bool>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																<bool key="NSIsBordered">YES</bool>
-																<object class="NSColor" key="NSColor">
-																	<int key="NSColorSpace">1</int>
-																	<bytes key="NSRGB">MC4wNTgxMzA0OTg5OCAwLjA1NTU0MTg5OTA2IDEAA</bytes>
-																</object>
-															</object>
-															<object class="NSColorWell" id="258665417">
-																<reference key="NSNextResponder" ref="402415888"/>
-																<int key="NSvFlags">269</int>
-																<set class="NSMutableSet" key="NSDragTypes">
-																	<object class="NSMutableString">
-																		<characters key="NS.bytes">NSColor pasteboard type</characters>
-																	</object>
-																</set>
-																<string key="NSFrame">{{211, 301}, {20, 20}}</string>
-																<reference key="NSSuperview" ref="402415888"/>
-																<reference key="NSNextKeyView" ref="233102631"/>
-																<int key="NSTag">21</int>
-																<bool key="NSEnabled">YES</bool>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																<bool key="NSIsBordered">YES</bool>
-																<object class="NSColor" key="NSColor">
-																	<int key="NSColorSpace">1</int>
-																	<bytes key="NSRGB">MC4wNTgxMzA0OTg5OCAwLjA1NTU0MTg5OTA2IDEAA</bytes>
-																</object>
-															</object>
-															<object class="NSColorWell" id="233102631">
-																<reference key="NSNextResponder" ref="402415888"/>
-																<int key="NSvFlags">269</int>
-																<set class="NSMutableSet" key="NSDragTypes">
-																	<object class="NSMutableString">
-																		<characters key="NS.bytes">NSColor pasteboard type</characters>
-																	</object>
-																</set>
-																<string key="NSFrame">{{232, 301}, {20, 20}}</string>
-																<reference key="NSSuperview" ref="402415888"/>
-																<reference key="NSNextKeyView" ref="350197855"/>
-																<int key="NSTag">22</int>
-																<bool key="NSEnabled">YES</bool>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																<bool key="NSIsBordered">YES</bool>
-																<object class="NSColor" key="NSColor">
-																	<int key="NSColorSpace">1</int>
-																	<bytes key="NSRGB">MC4wNTgxMzA0OTg5OCAwLjA1NTU0MTg5OTA2IDEAA</bytes>
-																</object>
-															</object>
-															<object class="NSColorWell" id="350197855">
-																<reference key="NSNextResponder" ref="402415888"/>
-																<int key="NSvFlags">269</int>
-																<set class="NSMutableSet" key="NSDragTypes">
-																	<object class="NSMutableString">
-																		<characters key="NS.bytes">NSColor pasteboard type</characters>
-																	</object>
-																</set>
-																<string key="NSFrame">{{253, 301}, {20, 20}}</string>
-																<reference key="NSSuperview" ref="402415888"/>
-																<reference key="NSNextKeyView" ref="78293204"/>
-																<int key="NSTag">23</int>
-																<bool key="NSEnabled">YES</bool>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																<bool key="NSIsBordered">YES</bool>
-																<object class="NSColor" key="NSColor">
-																	<int key="NSColorSpace">1</int>
-																	<bytes key="NSRGB">MC4wNTgxMzA0OTg5OCAwLjA1NTU0MTg5OTA2IDEAA</bytes>
-																</object>
-															</object>
-															<object class="NSColorWell" id="78293204">
-																<reference key="NSNextResponder" ref="402415888"/>
-																<int key="NSvFlags">269</int>
-																<set class="NSMutableSet" key="NSDragTypes">
-																	<object class="NSMutableString">
-																		<characters key="NS.bytes">NSColor pasteboard type</characters>
-																	</object>
-																</set>
-																<string key="NSFrame">{{274, 301}, {20, 20}}</string>
-																<reference key="NSSuperview" ref="402415888"/>
-																<reference key="NSNextKeyView" ref="782529362"/>
-																<int key="NSTag">24</int>
-																<bool key="NSEnabled">YES</bool>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																<bool key="NSIsBordered">YES</bool>
-																<object class="NSColor" key="NSColor">
-																	<int key="NSColorSpace">1</int>
-																	<bytes key="NSRGB">MC4wNTgxMzA0OTg5OCAwLjA1NTU0MTg5OTA2IDEAA</bytes>
-																</object>
-															</object>
-															<object class="NSColorWell" id="782529362">
-																<reference key="NSNextResponder" ref="402415888"/>
-																<int key="NSvFlags">269</int>
-																<set class="NSMutableSet" key="NSDragTypes">
-																	<object class="NSMutableString">
-																		<characters key="NS.bytes">NSColor pasteboard type</characters>
-																	</object>
-																</set>
-																<string key="NSFrame">{{295, 301}, {20, 20}}</string>
-																<reference key="NSSuperview" ref="402415888"/>
-																<reference key="NSNextKeyView" ref="216298000"/>
-																<int key="NSTag">25</int>
-																<bool key="NSEnabled">YES</bool>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																<bool key="NSIsBordered">YES</bool>
-																<object class="NSColor" key="NSColor">
-																	<int key="NSColorSpace">1</int>
-																	<bytes key="NSRGB">MC4wNTgxMzA0OTg5OCAwLjA1NTU0MTg5OTA2IDEAA</bytes>
-																</object>
-															</object>
-															<object class="NSColorWell" id="216298000">
-																<reference key="NSNextResponder" ref="402415888"/>
-																<int key="NSvFlags">269</int>
-																<set class="NSMutableSet" key="NSDragTypes">
-																	<object class="NSMutableString">
-																		<characters key="NS.bytes">NSColor pasteboard type</characters>
-																	</object>
-																</set>
-																<string key="NSFrame">{{316, 301}, {20, 20}}</string>
-																<reference key="NSSuperview" ref="402415888"/>
-																<reference key="NSNextKeyView" ref="576768000"/>
-																<int key="NSTag">26</int>
-																<bool key="NSEnabled">YES</bool>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																<bool key="NSIsBordered">YES</bool>
-																<object class="NSColor" key="NSColor">
-																	<int key="NSColorSpace">1</int>
-																	<bytes key="NSRGB">MC4wNTgxMzA0OTg5OCAwLjA1NTU0MTg5OTA2IDEAA</bytes>
-																</object>
-															</object>
-															<object class="NSColorWell" id="576768000">
-																<reference key="NSNextResponder" ref="402415888"/>
-																<int key="NSvFlags">269</int>
-																<set class="NSMutableSet" key="NSDragTypes">
-																	<object class="NSMutableString">
-																		<characters key="NS.bytes">NSColor pasteboard type</characters>
-																	</object>
-																</set>
-																<string key="NSFrame">{{337, 301}, {20, 20}}</string>
-																<reference key="NSSuperview" ref="402415888"/>
-																<reference key="NSNextKeyView" ref="44841208"/>
-																<int key="NSTag">27</int>
-																<bool key="NSEnabled">YES</bool>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																<bool key="NSIsBordered">YES</bool>
-																<object class="NSColor" key="NSColor">
-																	<int key="NSColorSpace">1</int>
-																	<bytes key="NSRGB">MC4wNTgxMzA0OTg5OCAwLjA1NTU0MTg5OTA2IDEAA</bytes>
-																</object>
-															</object>
-															<object class="NSColorWell" id="44841208">
-																<reference key="NSNextResponder" ref="402415888"/>
-																<int key="NSvFlags">269</int>
-																<set class="NSMutableSet" key="NSDragTypes">
-																	<object class="NSMutableString">
-																		<characters key="NS.bytes">NSColor pasteboard type</characters>
-																	</object>
-																</set>
-																<string key="NSFrame">{{358, 301}, {20, 20}}</string>
-																<reference key="NSSuperview" ref="402415888"/>
-																<reference key="NSNextKeyView" ref="282776959"/>
-																<int key="NSTag">28</int>
-																<bool key="NSEnabled">YES</bool>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																<bool key="NSIsBordered">YES</bool>
-																<object class="NSColor" key="NSColor">
-																	<int key="NSColorSpace">1</int>
-																	<bytes key="NSRGB">MC4wNTgxMzA0OTg5OCAwLjA1NTU0MTg5OTA2IDEAA</bytes>
-																</object>
-															</object>
-															<object class="NSColorWell" id="282776959">
-																<reference key="NSNextResponder" ref="402415888"/>
-																<int key="NSvFlags">269</int>
-																<set class="NSMutableSet" key="NSDragTypes">
-																	<object class="NSMutableString">
-																		<characters key="NS.bytes">NSColor pasteboard type</characters>
-																	</object>
-																</set>
-																<string key="NSFrame">{{379, 301}, {20, 20}}</string>
-																<reference key="NSSuperview" ref="402415888"/>
-																<reference key="NSNextKeyView" ref="350511929"/>
-																<int key="NSTag">29</int>
-																<bool key="NSEnabled">YES</bool>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																<bool key="NSIsBordered">YES</bool>
-																<object class="NSColor" key="NSColor">
-																	<int key="NSColorSpace">1</int>
-																	<bytes key="NSRGB">MC4wNTgxMzA0OTg5OCAwLjA1NTU0MTg5OTA2IDEAA</bytes>
-																</object>
-															</object>
-															<object class="NSColorWell" id="350511929">
-																<reference key="NSNextResponder" ref="402415888"/>
-																<int key="NSvFlags">269</int>
-																<set class="NSMutableSet" key="NSDragTypes">
-																	<object class="NSMutableString">
-																		<characters key="NS.bytes">NSColor pasteboard type</characters>
-																	</object>
-																</set>
-																<string key="NSFrame">{{400, 301}, {20, 20}}</string>
-																<reference key="NSSuperview" ref="402415888"/>
-																<reference key="NSNextKeyView" ref="968109138"/>
-																<int key="NSTag">30</int>
-																<bool key="NSEnabled">YES</bool>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																<bool key="NSIsBordered">YES</bool>
-																<object class="NSColor" key="NSColor">
-																	<int key="NSColorSpace">1</int>
-																	<bytes key="NSRGB">MC4wNTgxMzA0OTg5OCAwLjA1NTU0MTg5OTA2IDEAA</bytes>
-																</object>
-															</object>
-															<object class="NSColorWell" id="968109138">
-																<reference key="NSNextResponder" ref="402415888"/>
-																<int key="NSvFlags">269</int>
-																<set class="NSMutableSet" key="NSDragTypes">
-																	<object class="NSMutableString">
-																		<characters key="NS.bytes">NSColor pasteboard type</characters>
-																	</object>
-																</set>
-																<string key="NSFrame">{{421, 301}, {20, 20}}</string>
-																<reference key="NSSuperview" ref="402415888"/>
-																<reference key="NSNextKeyView" ref="193332999"/>
-																<int key="NSTag">31</int>
-																<bool key="NSEnabled">YES</bool>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																<bool key="NSIsBordered">YES</bool>
-																<object class="NSColor" key="NSColor">
-																	<int key="NSColorSpace">1</int>
-																	<bytes key="NSRGB">MC4wNTgxMzA0OTg5OCAwLjA1NTU0MTg5OTA2IDEAA</bytes>
-																</object>
-															</object>
-															<object class="NSTextField" id="193332999">
-																<reference key="NSNextResponder" ref="402415888"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{14, 275}, {87, 17}}</string>
-																<reference key="NSSuperview" ref="402415888"/>
-																<reference key="NSNextKeyView" ref="118049744"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSTextFieldCell" key="NSCell" id="991339367">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">71303168</int>
-																	<string key="NSContents">Foreground:</string>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="193332999"/>
-																	<reference key="NSBackgroundColor" ref="1007130360"/>
-																	<reference key="NSTextColor" ref="725989266"/>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSColorWell" id="118049744">
-																<reference key="NSNextResponder" ref="402415888"/>
-																<int key="NSvFlags">269</int>
-																<set class="NSMutableSet" key="NSDragTypes">
-																	<object class="NSMutableString">
-																		<characters key="NS.bytes">NSColor pasteboard type</characters>
-																	</object>
-																</set>
-																<string key="NSFrame">{{106, 275}, {20, 20}}</string>
-																<reference key="NSSuperview" ref="402415888"/>
-																<reference key="NSNextKeyView" ref="722652568"/>
-																<int key="NSTag">34</int>
-																<bool key="NSEnabled">YES</bool>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																<bool key="NSIsBordered">YES</bool>
-																<object class="NSColor" key="NSColor">
-																	<int key="NSColorSpace">1</int>
-																	<bytes key="NSRGB">MC4wNTgxMzA0OTg5OCAwLjA1NTU0MTg5OTA2IDEAA</bytes>
-																</object>
-															</object>
-															<object class="NSTextField" id="722652568">
-																<reference key="NSNextResponder" ref="402415888"/>
-																<int key="NSvFlags">269</int>
-																<string key="NSFrame">{{166, 275}, {124, 17}}</string>
-																<reference key="NSSuperview" ref="402415888"/>
-																<reference key="NSNextKeyView" ref="180153678"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSTextFieldCell" key="NSCell" id="742588452">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">71303168</int>
-																	<string key="NSContents">Background:</string>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="722652568"/>
-																	<reference key="NSBackgroundColor" ref="1007130360"/>
-																	<reference key="NSTextColor" ref="725989266"/>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSColorWell" id="180153678">
-																<reference key="NSNextResponder" ref="402415888"/>
-																<int key="NSvFlags">269</int>
-																<set class="NSMutableSet" key="NSDragTypes">
-																	<object class="NSMutableString">
-																		<characters key="NS.bytes">NSColor pasteboard type</characters>
-																	</object>
-																</set>
-																<string key="NSFrame">{{295, 275}, {20, 20}}</string>
-																<reference key="NSSuperview" ref="402415888"/>
-																<reference key="NSNextKeyView" ref="687336195"/>
-																<int key="NSTag">35</int>
-																<bool key="NSEnabled">YES</bool>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																<bool key="NSIsBordered">YES</bool>
-																<object class="NSColor" key="NSColor">
-																	<int key="NSColorSpace">1</int>
-																	<bytes key="NSRGB">MC4wNTgxMzA0OTg5OCAwLjA1NTU0MTg5OTA2IDEAA</bytes>
-																</object>
-															</object>
-															<object class="NSTextField" id="687336195">
-																<reference key="NSNextResponder" ref="402415888"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{14, 241}, {205, 20}}</string>
-																<reference key="NSSuperview" ref="402415888"/>
-																<reference key="NSNextKeyView" ref="638265677"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSTextFieldCell" key="NSCell" id="624198228">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">4194304</int>
-																	<string key="NSContents">Marking Text</string>
-																	<reference key="NSSupport" ref="29"/>
-																	<reference key="NSControlView" ref="687336195"/>
-																	<reference key="NSBackgroundColor" ref="1007130360"/>
-																	<reference key="NSTextColor" ref="725989266"/>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSTextField" id="638265677">
-																<reference key="NSNextResponder" ref="402415888"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{14, 213}, {87, 17}}</string>
-																<reference key="NSSuperview" ref="402415888"/>
-																<reference key="NSNextKeyView" ref="43449478"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSTextFieldCell" key="NSCell" id="881833546">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">71303168</int>
-																	<string key="NSContents">Foreground:</string>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="638265677"/>
-																	<reference key="NSBackgroundColor" ref="1007130360"/>
-																	<reference key="NSTextColor" ref="725989266"/>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSColorWell" id="43449478">
-																<reference key="NSNextResponder" ref="402415888"/>
-																<int key="NSvFlags">269</int>
-																<set class="NSMutableSet" key="NSDragTypes">
-																	<object class="NSMutableString">
-																		<characters key="NS.bytes">NSColor pasteboard type</characters>
-																	</object>
-																</set>
-																<string key="NSFrame">{{106, 213}, {20, 20}}</string>
-																<reference key="NSSuperview" ref="402415888"/>
-																<reference key="NSNextKeyView" ref="795324312"/>
-																<int key="NSTag">32</int>
-																<bool key="NSEnabled">YES</bool>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																<bool key="NSIsBordered">YES</bool>
-																<object class="NSColor" key="NSColor">
-																	<int key="NSColorSpace">1</int>
-																	<bytes key="NSRGB">MC4wNTgxMzA0OTg5OCAwLjA1NTU0MTg5OTA2IDEAA</bytes>
-																</object>
-															</object>
-															<object class="NSTextField" id="795324312">
-																<reference key="NSNextResponder" ref="402415888"/>
-																<int key="NSvFlags">269</int>
-																<string key="NSFrame">{{166, 213}, {124, 17}}</string>
-																<reference key="NSSuperview" ref="402415888"/>
-																<reference key="NSNextKeyView" ref="1063522251"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSTextFieldCell" key="NSCell" id="175839490">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">71303168</int>
-																	<string key="NSContents">Background:</string>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="795324312"/>
-																	<reference key="NSBackgroundColor" ref="1007130360"/>
-																	<reference key="NSTextColor" ref="725989266"/>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSColorWell" id="1063522251">
-																<reference key="NSNextResponder" ref="402415888"/>
-																<int key="NSvFlags">269</int>
-																<set class="NSMutableSet" key="NSDragTypes">
-																	<object class="NSMutableString">
-																		<characters key="NS.bytes">NSColor pasteboard type</characters>
-																	</object>
-																</set>
-																<string key="NSFrame">{{295, 213}, {20, 20}}</string>
-																<reference key="NSSuperview" ref="402415888"/>
-																<reference key="NSNextKeyView" ref="1031955050"/>
-																<int key="NSTag">33</int>
-																<bool key="NSEnabled">YES</bool>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																<bool key="NSIsBordered">YES</bool>
-																<object class="NSColor" key="NSColor">
-																	<int key="NSColorSpace">1</int>
-																	<bytes key="NSRGB">MC4wNTgxMzA0OTg5OCAwLjA1NTU0MTg5OTA2IDEAA</bytes>
-																</object>
-															</object>
-															<object class="NSTextField" id="1031955050">
-																<reference key="NSNextResponder" ref="402415888"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{14, 178}, {205, 21}}</string>
-																<reference key="NSSuperview" ref="402415888"/>
-																<reference key="NSNextKeyView" ref="686202698"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSTextFieldCell" key="NSCell" id="1036308174">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">4194304</int>
-																	<string key="NSContents">Interface Colors</string>
-																	<reference key="NSSupport" ref="29"/>
-																	<reference key="NSControlView" ref="1031955050"/>
-																	<reference key="NSBackgroundColor" ref="1007130360"/>
-																	<reference key="NSTextColor" ref="725989266"/>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSTextField" id="686202698">
-																<reference key="NSNextResponder" ref="402415888"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{14, 153}, {87, 17}}</string>
-																<reference key="NSSuperview" ref="402415888"/>
-																<reference key="NSNextKeyView" ref="514898890"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSTextFieldCell" key="NSCell" id="415716680">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">71303168</int>
-																	<string key="NSContents">New data:</string>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="686202698"/>
-																	<reference key="NSBackgroundColor" ref="1007130360"/>
-																	<reference key="NSTextColor" ref="725989266"/>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSColorWell" id="514898890">
-																<reference key="NSNextResponder" ref="402415888"/>
-																<int key="NSvFlags">269</int>
-																<set class="NSMutableSet" key="NSDragTypes">
-																	<object class="NSMutableString">
-																		<characters key="NS.bytes">NSColor pasteboard type</characters>
-																	</object>
-																</set>
-																<string key="NSFrame">{{106, 153}, {20, 20}}</string>
-																<reference key="NSSuperview" ref="402415888"/>
-																<reference key="NSNextKeyView" ref="513306894"/>
-																<int key="NSTag">37</int>
-																<bool key="NSEnabled">YES</bool>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																<bool key="NSIsBordered">YES</bool>
-																<object class="NSColor" key="NSColor">
-																	<int key="NSColorSpace">1</int>
-																	<bytes key="NSRGB">MC4wNTgxMzA0OTg5OCAwLjA1NTU0MTg5OTA2IDEAA</bytes>
-																</object>
-															</object>
-															<object class="NSTextField" id="513306894">
-																<reference key="NSNextResponder" ref="402415888"/>
-																<int key="NSvFlags">269</int>
-																<string key="NSFrame">{{166, 153}, {124, 17}}</string>
-																<reference key="NSSuperview" ref="402415888"/>
-																<reference key="NSNextKeyView" ref="409264205"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSTextFieldCell" key="NSCell" id="154238410">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">71303168</int>
-																	<string key="NSContents">Highlight:</string>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="513306894"/>
-																	<reference key="NSBackgroundColor" ref="1007130360"/>
-																	<reference key="NSTextColor" ref="725989266"/>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSColorWell" id="409264205">
-																<reference key="NSNextResponder" ref="402415888"/>
-																<int key="NSvFlags">269</int>
-																<set class="NSMutableSet" key="NSDragTypes">
-																	<object class="NSMutableString">
-																		<characters key="NS.bytes">NSColor pasteboard type</characters>
-																	</object>
-																</set>
-																<string key="NSFrame">{{295, 153}, {20, 20}}</string>
-																<reference key="NSSuperview" ref="402415888"/>
-																<reference key="NSNextKeyView" ref="690043882"/>
-																<int key="NSTag">38</int>
-																<bool key="NSEnabled">YES</bool>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																<bool key="NSIsBordered">YES</bool>
-																<object class="NSColor" key="NSColor">
-																	<int key="NSColorSpace">1</int>
-																	<bytes key="NSRGB">MC4wNTgxMzA0OTg5OCAwLjA1NTU0MTg5OTA2IDEAA</bytes>
-																</object>
-															</object>
-															<object class="NSTextField" id="690043882">
-																<reference key="NSNextResponder" ref="402415888"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{14, 128}, {87, 17}}</string>
-																<reference key="NSSuperview" ref="402415888"/>
-																<reference key="NSNextKeyView" ref="831000751"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSTextFieldCell" key="NSCell" id="708814508">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">71303168</int>
-																	<string key="NSContents">New message:</string>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="690043882"/>
-																	<reference key="NSBackgroundColor" ref="1007130360"/>
-																	<reference key="NSTextColor" ref="725989266"/>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSColorWell" id="831000751">
-																<reference key="NSNextResponder" ref="402415888"/>
-																<int key="NSvFlags">269</int>
-																<set class="NSMutableSet" key="NSDragTypes">
-																	<object class="NSMutableString">
-																		<characters key="NS.bytes">NSColor pasteboard type</characters>
-																	</object>
-																</set>
-																<string key="NSFrame">{{106, 128}, {20, 20}}</string>
-																<reference key="NSSuperview" ref="402415888"/>
-																<reference key="NSNextKeyView" ref="44557163"/>
-																<int key="NSTag">39</int>
-																<bool key="NSEnabled">YES</bool>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																<bool key="NSIsBordered">YES</bool>
-																<object class="NSColor" key="NSColor">
-																	<int key="NSColorSpace">1</int>
-																	<bytes key="NSRGB">MC4wNTgxMzA0OTg5OCAwLjA1NTU0MTg5OTA2IDEAA</bytes>
-																</object>
-															</object>
-															<object class="NSTextField" id="44557163">
-																<reference key="NSNextResponder" ref="402415888"/>
-																<int key="NSvFlags">269</int>
-																<string key="NSFrame">{{166, 128}, {124, 17}}</string>
-																<reference key="NSSuperview" ref="402415888"/>
-																<reference key="NSNextKeyView" ref="272186419"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSTextFieldCell" key="NSCell" id="511391313">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">71303168</int>
-																	<string key="NSContents">Away user:</string>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="44557163"/>
-																	<reference key="NSBackgroundColor" ref="1007130360"/>
-																	<reference key="NSTextColor" ref="725989266"/>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSColorWell" id="272186419">
-																<reference key="NSNextResponder" ref="402415888"/>
-																<int key="NSvFlags">269</int>
-																<set class="NSMutableSet" key="NSDragTypes">
-																	<object class="NSMutableString">
-																		<characters key="NS.bytes">NSColor pasteboard type</characters>
-																	</object>
-																</set>
-																<string key="NSFrame">{{295, 128}, {20, 20}}</string>
-																<reference key="NSSuperview" ref="402415888"/>
-																<reference key="NSNextKeyView" ref="479388100"/>
-																<int key="NSTag">40</int>
-																<bool key="NSEnabled">YES</bool>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																<bool key="NSIsBordered">YES</bool>
-																<object class="NSColor" key="NSColor">
-																	<int key="NSColorSpace">1</int>
-																	<bytes key="NSRGB">MC4wNTgxMzA0OTg5OCAwLjA1NTU0MTg5OTA2IDEAA</bytes>
-																</object>
-															</object>
-															<object class="NSButton" id="479388100">
-																<reference key="NSNextResponder" ref="402415888"/>
-																<int key="NSvFlags">294</int>
-																<string key="NSFrame">{{11, 12}, {210, 32}}</string>
-																<reference key="NSSuperview" ref="402415888"/>
-																<reference key="NSNextKeyView" ref="501949360"/>
-																<string key="NSReuseIdentifierKey">_NS:9</string>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSButtonCell" key="NSCell" id="911785969">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">134217728</int>
-																	<string key="NSContents">Load Default Colors</string>
-																	<reference key="NSSupport" ref="218849127"/>
-																	<string key="NSCellIdentifier">_NS:9</string>
-																	<reference key="NSControlView" ref="479388100"/>
-																	<int key="NSButtonFlags">-2038284288</int>
-																	<int key="NSButtonFlags2">129</int>
-																	<string key="NSAlternateContents"/>
-																	<string key="NSKeyEquivalent"/>
-																	<int key="NSPeriodicDelay">200</int>
-																	<int key="NSPeriodicInterval">25</int>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSButton" id="501949360">
-																<reference key="NSNextResponder" ref="402415888"/>
-																<int key="NSvFlags">291</int>
-																<string key="NSFrame">{{225, 12}, {210, 32}}</string>
-																<reference key="NSSuperview" ref="402415888"/>
-																<reference key="NSNextKeyView" ref="1053574686"/>
-																<string key="NSReuseIdentifierKey">_NS:9</string>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSButtonCell" key="NSCell" id="329783002">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">134217728</int>
-																	<string key="NSContents">Load From File...</string>
-																	<reference key="NSSupport" ref="218849127"/>
-																	<string key="NSCellIdentifier">_NS:9</string>
-																	<reference key="NSControlView" ref="501949360"/>
-																	<int key="NSButtonFlags">-2038284288</int>
-																	<int key="NSButtonFlags2">129</int>
-																	<string key="NSAlternateContents"/>
-																	<string key="NSKeyEquivalent"/>
-																	<int key="NSPeriodicDelay">200</int>
-																	<int key="NSPeriodicInterval">25</int>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-														</array>
-														<string key="NSFrameSize">{449, 406}</string>
-														<reference key="NSNextKeyView" ref="48224885"/>
-													</object>
-													<reference key="NSColor" ref="1007130360"/>
-													<reference key="NSTabView" ref="1053574686"/>
-												</object>
-												<object class="NSTabViewItem" id="23773977">
-													<object class="NSView" key="NSView" id="150217438">
-														<nil key="NSNextResponder"/>
-														<int key="NSvFlags">256</int>
-														<array class="NSMutableArray" key="NSSubviews">
-															<object class="NSButton" id="366330173">
-																<reference key="NSNextResponder" ref="150217438"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{29, 344}, {237, 19}}</string>
-																<reference key="NSSuperview" ref="150217438"/>
-																<reference key="NSNextKeyView" ref="666364138"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSButtonCell" key="NSCell" id="507186717">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">131072</int>
-																	<string key="NSContents">Beep on private messages</string>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="366330173"/>
-																	<int key="NSButtonFlags">1211912448</int>
-																	<int key="NSButtonFlags2">2</int>
-																	<reference key="NSNormalImage" ref="557231633"/>
-																	<reference key="NSAlternateImage" ref="152492997"/>
-																	<string key="NSAlternateContents"/>
-																	<string key="NSKeyEquivalent"/>
-																	<int key="NSPeriodicDelay">200</int>
-																	<int key="NSPeriodicInterval">25</int>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSButton" id="666364138">
-																<reference key="NSNextResponder" ref="150217438"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{29, 323}, {237, 19}}</string>
-																<reference key="NSSuperview" ref="150217438"/>
-																<reference key="NSNextKeyView" ref="998640248"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSButtonCell" key="NSCell" id="450133651">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">131072</int>
-																	<string key="NSContents">Beep on channel messages</string>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="666364138"/>
-																	<int key="NSButtonFlags">1211912448</int>
-																	<int key="NSButtonFlags2">2</int>
-																	<reference key="NSNormalImage" ref="557231633"/>
-																	<reference key="NSAlternateImage" ref="152492997"/>
-																	<string key="NSAlternateContents"/>
-																	<string key="NSKeyEquivalent"/>
-																	<int key="NSPeriodicDelay">200</int>
-																	<int key="NSPeriodicInterval">25</int>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSButton" id="998640248">
-																<reference key="NSNextResponder" ref="150217438"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{29, 302}, {237, 19}}</string>
-																<reference key="NSSuperview" ref="150217438"/>
-																<reference key="NSNextKeyView" ref="904793015"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSButtonCell" key="NSCell" id="875548376">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">131072</int>
-																	<string key="NSContents">Beep on highlighted messages</string>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="998640248"/>
-																	<int key="NSButtonFlags">1211912448</int>
-																	<int key="NSButtonFlags2">2</int>
-																	<reference key="NSNormalImage" ref="557231633"/>
-																	<reference key="NSAlternateImage" ref="152492997"/>
-																	<string key="NSAlternateContents"/>
-																	<string key="NSKeyEquivalent"/>
-																	<int key="NSPeriodicDelay">200</int>
-																	<int key="NSPeriodicInterval">25</int>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSTextField" id="746284896">
-																<reference key="NSNextResponder" ref="150217438"/>
-																<int key="NSvFlags">266</int>
-																<string key="NSFrame">{{219, 213}, {210, 19}}</string>
-																<reference key="NSSuperview" ref="150217438"/>
-																<reference key="NSNextKeyView" ref="1053086435"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSTextFieldCell" key="NSCell" id="843263007">
-																	<int key="NSCellFlags">-1804599231</int>
-																	<int key="NSCellFlags2">4195328</int>
-																	<string key="NSContents"/>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="746284896"/>
-																	<bool key="NSDrawsBackground">YES</bool>
-																	<reference key="NSBackgroundColor" ref="265355499"/>
-																	<reference key="NSTextColor" ref="328927124"/>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSTextField" id="1057046117">
-																<reference key="NSNextResponder" ref="150217438"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{6, 212}, {208, 17}}</string>
-																<reference key="NSSuperview" ref="150217438"/>
-																<reference key="NSNextKeyView" ref="746284896"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSTextFieldCell" key="NSCell" id="71796614">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">71303168</int>
-																	<string key="NSContents">Extra words to highlight:</string>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="1057046117"/>
-																	<reference key="NSBackgroundColor" ref="1007130360"/>
-																	<reference key="NSTextColor" ref="725989266"/>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSTextField" id="637075528">
-																<reference key="NSNextResponder" ref="150217438"/>
-																<int key="NSvFlags">266</int>
-																<string key="NSFrame">{{219, 186}, {210, 19}}</string>
-																<reference key="NSSuperview" ref="150217438"/>
-																<reference key="NSNextKeyView" ref="779767674"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSTextFieldCell" key="NSCell" id="20224732">
-																	<int key="NSCellFlags">-1804599231</int>
-																	<int key="NSCellFlags2">4195328</int>
-																	<string key="NSContents"/>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="637075528"/>
-																	<bool key="NSDrawsBackground">YES</bool>
-																	<reference key="NSBackgroundColor" ref="265355499"/>
-																	<reference key="NSTextColor" ref="328927124"/>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSTextField" id="1053086435">
-																<reference key="NSNextResponder" ref="150217438"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{6, 185}, {208, 17}}</string>
-																<reference key="NSSuperview" ref="150217438"/>
-																<reference key="NSNextKeyView" ref="637075528"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSTextFieldCell" key="NSCell" id="943834700">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">71303168</int>
-																	<string key="NSContents">Nick names not to highlight:</string>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="1053086435"/>
-																	<reference key="NSBackgroundColor" ref="1007130360"/>
-																	<reference key="NSTextColor" ref="725989266"/>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSTextField" id="1028551236">
-																<reference key="NSNextResponder" ref="150217438"/>
-																<int key="NSvFlags">266</int>
-																<string key="NSFrame">{{219, 159}, {210, 19}}</string>
-																<reference key="NSSuperview" ref="150217438"/>
-																<reference key="NSNextKeyView" ref="962156983"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSTextFieldCell" key="NSCell" id="622607969">
-																	<int key="NSCellFlags">-1804599231</int>
-																	<int key="NSCellFlags2">4195328</int>
-																	<string key="NSContents"/>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="1028551236"/>
-																	<bool key="NSDrawsBackground">YES</bool>
-																	<reference key="NSBackgroundColor" ref="265355499"/>
-																	<reference key="NSTextColor" ref="328927124"/>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSTextField" id="779767674">
-																<reference key="NSNextResponder" ref="150217438"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{6, 161}, {208, 14}}</string>
-																<reference key="NSSuperview" ref="150217438"/>
-																<reference key="NSNextKeyView" ref="1028551236"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSTextFieldCell" key="NSCell" id="106735145">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">71303168</int>
-																	<string key="NSContents">Nick names to always highlight:</string>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="779767674"/>
-																	<reference key="NSBackgroundColor" ref="1007130360"/>
-																	<reference key="NSTextColor" ref="725989266"/>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSTextField" id="904793015">
-																<reference key="NSNextResponder" ref="150217438"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{17, 262}, {153, 17}}</string>
-																<reference key="NSSuperview" ref="150217438"/>
-																<reference key="NSNextKeyView" ref="1047641055"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSTextFieldCell" key="NSCell" id="880650260">
-																	<int key="NSCellFlags">68157504</int>
-																	<int key="NSCellFlags2">272630784</int>
-																	<string key="NSContents">Highlighted Messages</string>
-																	<reference key="NSSupport" ref="60143749"/>
-																	<reference key="NSControlView" ref="904793015"/>
-																	<reference key="NSBackgroundColor" ref="1007130360"/>
-																	<reference key="NSTextColor" ref="725989266"/>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSTextField" id="967409140">
-																<reference key="NSNextResponder" ref="150217438"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{17, 369}, {153, 17}}</string>
-																<reference key="NSSuperview" ref="150217438"/>
-																<reference key="NSNextKeyView" ref="366330173"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSTextFieldCell" key="NSCell" id="335672329">
-																	<int key="NSCellFlags">68157504</int>
-																	<int key="NSCellFlags2">272630784</int>
-																	<string key="NSContents">Alerts</string>
-																	<reference key="NSSupport" ref="60143749"/>
-																	<reference key="NSControlView" ref="967409140"/>
-																	<reference key="NSBackgroundColor" ref="1007130360"/>
-																	<reference key="NSTextColor" ref="725989266"/>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSTextField" id="1047641055">
-																<reference key="NSNextResponder" ref="150217438"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{29, 240}, {415, 14}}</string>
-																<reference key="NSSuperview" ref="150217438"/>
-																<reference key="NSNextKeyView" ref="1057046117"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSTextFieldCell" key="NSCell" id="694279702">
-																	<int key="NSCellFlags">68157504</int>
-																	<int key="NSCellFlags2">272761856</int>
-																	<string key="NSContents">Highlighted messages are ones where your nickname is mentioned, but also:</string>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="1047641055"/>
-																	<reference key="NSBackgroundColor" ref="1007130360"/>
-																	<reference key="NSTextColor" ref="725989266"/>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSTextField" id="962156983">
-																<reference key="NSNextResponder" ref="150217438"/>
-																<int key="NSvFlags">265</int>
-																<string key="NSFrame">{{166, 123}, {266, 28}}</string>
-																<reference key="NSSuperview" ref="150217438"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSTextFieldCell" key="NSCell" id="1072147515">
-																	<int key="NSCellFlags">68157504</int>
-																	<int key="NSCellFlags2">71435264</int>
-																	<string key="NSContents">Separate multiple words with commas. Wildcards are accepted.</string>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="962156983"/>
-																	<reference key="NSBackgroundColor" ref="1007130360"/>
-																	<reference key="NSTextColor" ref="725989266"/>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-														</array>
-														<string key="NSFrameSize">{449, 406}</string>
-														<reference key="NSNextKeyView" ref="967409140"/>
-													</object>
-													<reference key="NSColor" ref="1007130360"/>
-													<reference key="NSTabView" ref="1053574686"/>
-												</object>
-												<object class="NSTabViewItem" id="633363925">
-													<object class="NSView" key="NSView" id="55856611">
-														<nil key="NSNextResponder"/>
-														<int key="NSvFlags">256</int>
-														<array class="NSMutableArray" key="NSSubviews">
-															<object class="NSTextField" id="223828555">
-																<reference key="NSNextResponder" ref="55856611"/>
-																<int key="NSvFlags">266</int>
-																<string key="NSFrame">{{128, 342}, {301, 19}}</string>
-																<reference key="NSSuperview" ref="55856611"/>
-																<reference key="NSNextKeyView" ref="108020218"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSTextFieldCell" key="NSCell" id="584215286">
-																	<int key="NSCellFlags">-1804599231</int>
-																	<int key="NSCellFlags2">4195328</int>
-																	<string key="NSContents"/>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="223828555"/>
-																	<bool key="NSDrawsBackground">YES</bool>
-																	<reference key="NSBackgroundColor" ref="265355499"/>
-																	<reference key="NSTextColor" ref="328927124"/>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSTextField" id="68392803">
-																<reference key="NSNextResponder" ref="55856611"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{17, 341}, {106, 17}}</string>
-																<reference key="NSSuperview" ref="55856611"/>
-																<reference key="NSNextKeyView" ref="223828555"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSTextFieldCell" key="NSCell" id="585272136">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">71303168</int>
-																	<string key="NSContents">Quit:</string>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="68392803"/>
-																	<reference key="NSBackgroundColor" ref="1007130360"/>
-																	<reference key="NSTextColor" ref="725989266"/>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSTextField" id="427166787">
-																<reference key="NSNextResponder" ref="55856611"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{17, 369}, {415, 17}}</string>
-																<reference key="NSSuperview" ref="55856611"/>
-																<reference key="NSNextKeyView" ref="68392803"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSTextFieldCell" key="NSCell" id="886433215">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">272633856</int>
-																	<string key="NSContents">Default Messages</string>
-																	<reference key="NSSupport" ref="60143749"/>
-																	<reference key="NSControlView" ref="427166787"/>
-																	<reference key="NSBackgroundColor" ref="1007130360"/>
-																	<reference key="NSTextColor" ref="725989266"/>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSTextField" id="127529838">
-																<reference key="NSNextResponder" ref="55856611"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{17, 234}, {415, 17}}</string>
-																<reference key="NSSuperview" ref="55856611"/>
-																<reference key="NSNextKeyView" ref="262685444"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSTextFieldCell" key="NSCell" id="598276151">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">272633856</int>
-																	<string key="NSContents">Away</string>
-																	<reference key="NSSupport" ref="60143749"/>
-																	<reference key="NSControlView" ref="127529838"/>
-																	<reference key="NSBackgroundColor" ref="1007130360"/>
-																	<reference key="NSTextColor" ref="725989266"/>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSTextField" id="458271500">
-																<reference key="NSNextResponder" ref="55856611"/>
-																<int key="NSvFlags">266</int>
-																<string key="NSFrame">{{128, 314}, {301, 19}}</string>
-																<reference key="NSSuperview" ref="55856611"/>
-																<reference key="NSNextKeyView" ref="107180245"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSTextFieldCell" key="NSCell" id="469446840">
-																	<int key="NSCellFlags">-1804599231</int>
-																	<int key="NSCellFlags2">4195328</int>
-																	<string key="NSContents"/>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="458271500"/>
-																	<bool key="NSDrawsBackground">YES</bool>
-																	<reference key="NSBackgroundColor" ref="265355499"/>
-																	<reference key="NSTextColor" ref="328927124"/>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSTextField" id="108020218">
-																<reference key="NSNextResponder" ref="55856611"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{17, 313}, {106, 17}}</string>
-																<reference key="NSSuperview" ref="55856611"/>
-																<reference key="NSNextKeyView" ref="458271500"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSTextFieldCell" key="NSCell" id="237938749">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">71303168</int>
-																	<string key="NSContents">Leave channel:</string>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="108020218"/>
-																	<reference key="NSBackgroundColor" ref="1007130360"/>
-																	<reference key="NSTextColor" ref="725989266"/>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSTextField" id="261722805">
-																<reference key="NSNextResponder" ref="55856611"/>
-																<int key="NSvFlags">266</int>
-																<string key="NSFrame">{{128, 287}, {301, 19}}</string>
-																<reference key="NSSuperview" ref="55856611"/>
-																<reference key="NSNextKeyView" ref="421761115"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSTextFieldCell" key="NSCell" id="272219725">
-																	<int key="NSCellFlags">-1804599231</int>
-																	<int key="NSCellFlags2">4195328</int>
-																	<string key="NSContents"/>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="261722805"/>
-																	<bool key="NSDrawsBackground">YES</bool>
-																	<reference key="NSBackgroundColor" ref="265355499"/>
-																	<reference key="NSTextColor" ref="328927124"/>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSTextField" id="107180245">
-																<reference key="NSNextResponder" ref="55856611"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{17, 286}, {106, 17}}</string>
-																<reference key="NSSuperview" ref="55856611"/>
-																<reference key="NSNextKeyView" ref="261722805"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSTextFieldCell" key="NSCell" id="293992041">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">71303168</int>
-																	<string key="NSContents">Away:</string>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="107180245"/>
-																	<reference key="NSBackgroundColor" ref="1007130360"/>
-																	<reference key="NSTextColor" ref="725989266"/>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSButton" id="262685444">
-																<reference key="NSNextResponder" ref="55856611"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{29, 209}, {267, 19}}</string>
-																<reference key="NSSuperview" ref="55856611"/>
-																<reference key="NSNextKeyView" ref="1055673271"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSButtonCell" key="NSCell" id="480489821">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">131072</int>
-																	<string key="NSContents">Announce away messages</string>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="262685444"/>
-																	<int key="NSButtonFlags">1211912448</int>
-																	<int key="NSButtonFlags2">2</int>
-																	<reference key="NSNormalImage" ref="557231633"/>
-																	<reference key="NSAlternateImage" ref="152492997"/>
-																	<string key="NSAlternateContents"/>
-																	<string key="NSKeyEquivalent"/>
-																	<int key="NSPeriodicDelay">200</int>
-																	<int key="NSPeriodicInterval">25</int>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSButton" id="1055673271">
-																<reference key="NSNextResponder" ref="55856611"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{29, 188}, {267, 19}}</string>
-																<reference key="NSSuperview" ref="55856611"/>
-																<reference key="NSNextKeyView" ref="123971144"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSButtonCell" key="NSCell" id="943369683">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">131072</int>
-																	<string key="NSContents">Show away once</string>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="1055673271"/>
-																	<int key="NSButtonFlags">1211912448</int>
-																	<int key="NSButtonFlags2">2</int>
-																	<reference key="NSNormalImage" ref="557231633"/>
-																	<reference key="NSAlternateImage" ref="152492997"/>
-																	<string key="NSAlternateContents"/>
-																	<string key="NSKeyEquivalent"/>
-																	<int key="NSPeriodicDelay">200</int>
-																	<int key="NSPeriodicInterval">25</int>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSButton" id="123971144">
-																<reference key="NSNextResponder" ref="55856611"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{29, 167}, {267, 19}}</string>
-																<reference key="NSSuperview" ref="55856611"/>
-																<reference key="NSNextKeyView" ref="531383733"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSButtonCell" key="NSCell" id="38837654">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">131072</int>
-																	<string key="NSContents">Automatically unmark away</string>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="123971144"/>
-																	<int key="NSButtonFlags">1211912448</int>
-																	<int key="NSButtonFlags2">2</int>
-																	<reference key="NSNormalImage" ref="557231633"/>
-																	<reference key="NSAlternateImage" ref="152492997"/>
-																	<string key="NSAlternateContents"/>
-																	<string key="NSKeyEquivalent"/>
-																	<int key="NSPeriodicDelay">200</int>
-																	<int key="NSPeriodicInterval">25</int>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSTextField" id="421761115">
-																<reference key="NSNextResponder" ref="55856611"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{17, 259}, {106, 17}}</string>
-																<reference key="NSSuperview" ref="55856611"/>
-																<reference key="NSNextKeyView" ref="588693457"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSTextFieldCell" key="NSCell" id="57504781">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">71303168</int>
-																	<string key="NSContents">Sleep:</string>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="421761115"/>
-																	<reference key="NSBackgroundColor" ref="1007130360"/>
-																	<reference key="NSTextColor" ref="725989266"/>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSTextField" id="588693457">
-																<reference key="NSNextResponder" ref="55856611"/>
-																<int key="NSvFlags">266</int>
-																<string key="NSFrame">{{128, 260}, {301, 19}}</string>
-																<reference key="NSSuperview" ref="55856611"/>
-																<reference key="NSNextKeyView" ref="127529838"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSTextFieldCell" key="NSCell" id="117096224">
-																	<int key="NSCellFlags">-1804599231</int>
-																	<int key="NSCellFlags2">4195328</int>
-																	<string key="NSContents"/>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="588693457"/>
-																	<bool key="NSDrawsBackground">YES</bool>
-																	<reference key="NSBackgroundColor" ref="265355499"/>
-																	<reference key="NSTextColor" ref="328927124"/>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSButton" id="531383733">
-																<reference key="NSNextResponder" ref="55856611"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{29, 146}, {267, 19}}</string>
-																<reference key="NSSuperview" ref="55856611"/>
-																<reference key="NSNextKeyView" ref="445128323"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSButtonCell" key="NSCell" id="902285033">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">131072</int>
-																	<string key="NSContents">/part channels on sleep</string>
-																	<reference key="NSSupport" ref="867044200"/>
-																	<reference key="NSControlView" ref="531383733"/>
-																	<int key="NSButtonFlags">1211912448</int>
-																	<int key="NSButtonFlags2">2</int>
-																	<reference key="NSNormalImage" ref="557231633"/>
-																	<reference key="NSAlternateImage" ref="152492997"/>
-																	<string key="NSAlternateContents"/>
-																	<string key="NSKeyEquivalent"/>
-																	<int key="NSPeriodicDelay">200</int>
-																	<int key="NSPeriodicInterval">25</int>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSButton" id="445128323">
-																<reference key="NSNextResponder" ref="55856611"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{29, 125}, {182, 19}}</string>
-																<reference key="NSSuperview" ref="55856611"/>
-																<reference key="NSNextKeyView" ref="672147861"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSButtonCell" key="NSCell" id="888164047">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">131072</int>
-																	<string key="NSContents">Auto-away after</string>
-																	<reference key="NSSupport" ref="867044200"/>
-																	<reference key="NSControlView" ref="445128323"/>
-																	<int key="NSButtonFlags">1211912448</int>
-																	<int key="NSButtonFlags2">2</int>
-																	<reference key="NSNormalImage" ref="557231633"/>
-																	<reference key="NSAlternateImage" ref="152492997"/>
-																	<string key="NSAlternateContents"/>
-																	<string key="NSKeyEquivalent"/>
-																	<int key="NSPeriodicDelay">200</int>
-																	<int key="NSPeriodicInterval">25</int>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSTextField" id="672147861">
-																<reference key="NSNextResponder" ref="55856611"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{209, 125}, {29, 19}}</string>
-																<reference key="NSSuperview" ref="55856611"/>
-																<reference key="NSNextKeyView" ref="871847337"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSTextFieldCell" key="NSCell" id="786534123">
-																	<int key="NSCellFlags">-1804599231</int>
-																	<int key="NSCellFlags2">4195328</int>
-																	<string key="NSContents"/>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="672147861"/>
-																	<bool key="NSDrawsBackground">YES</bool>
-																	<reference key="NSBackgroundColor" ref="265355499"/>
-																	<reference key="NSTextColor" ref="328927124"/>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSTextField" id="871847337">
-																<reference key="NSNextResponder" ref="55856611"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{243, 125}, {83, 17}}</string>
-																<reference key="NSSuperview" ref="55856611"/>
-																<reference key="NSNextKeyView" ref="1053574686"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSTextFieldCell" key="NSCell" id="743162796">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">4194304</int>
-																	<string key="NSContents">minutes</string>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="871847337"/>
-																	<reference key="NSBackgroundColor" ref="1007130360"/>
-																	<reference key="NSTextColor" ref="725989266"/>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-														</array>
-														<string key="NSFrameSize">{449, 406}</string>
-														<reference key="NSNextKeyView" ref="427166787"/>
-													</object>
-													<reference key="NSColor" ref="1007130360"/>
-													<reference key="NSTabView" ref="1053574686"/>
-												</object>
-												<object class="NSTabViewItem" id="513972833">
-													<object class="NSView" key="NSView" id="57587199">
-														<nil key="NSNextResponder"/>
-														<int key="NSvFlags">256</int>
-														<array class="NSMutableArray" key="NSSubviews">
-															<object class="NSTextField" id="288449918">
-																<reference key="NSNextResponder" ref="57587199"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{19, 304}, {153, 14}}</string>
-																<reference key="NSSuperview" ref="57587199"/>
-																<reference key="NSNextKeyView" ref="140016662"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSTextFieldCell" key="NSCell" id="192041138">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">71303168</int>
-																	<string key="NSContents">Log filename:</string>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="288449918"/>
-																	<reference key="NSBackgroundColor" ref="1007130360"/>
-																	<reference key="NSTextColor" ref="725989266"/>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSTextField" id="311410408">
-																<reference key="NSNextResponder" ref="57587199"/>
-																<int key="NSvFlags">266</int>
-																<string key="NSFrame">{{177, 217}, {252, 19}}</string>
-																<reference key="NSSuperview" ref="57587199"/>
-																<reference key="NSNextKeyView" ref="555959875"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSTextFieldCell" key="NSCell" id="908723235">
-																	<int key="NSCellFlags">-1804599231</int>
-																	<int key="NSCellFlags2">4195328</int>
-																	<string key="NSContents"/>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="311410408"/>
-																	<bool key="NSDrawsBackground">YES</bool>
-																	<reference key="NSBackgroundColor" ref="265355499"/>
-																	<reference key="NSTextColor" ref="328927124"/>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSTextField" id="102143362">
-																<reference key="NSNextResponder" ref="57587199"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{17, 220}, {155, 14}}</string>
-																<reference key="NSSuperview" ref="57587199"/>
-																<reference key="NSNextKeyView" ref="311410408"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSTextFieldCell" key="NSCell" id="573470832">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">71303168</int>
-																	<string key="NSContents">Log timestamp format:</string>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="102143362"/>
-																	<reference key="NSBackgroundColor" ref="1007130360"/>
-																	<reference key="NSTextColor" ref="725989266"/>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSTextField" id="140016662">
-																<reference key="NSNextResponder" ref="57587199"/>
-																<int key="NSvFlags">266</int>
-																<string key="NSFrame">{{177, 301}, {252, 19}}</string>
-																<reference key="NSSuperview" ref="57587199"/>
-																<reference key="NSNextKeyView" ref="546974449"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSTextFieldCell" key="NSCell" id="743545524">
-																	<int key="NSCellFlags">-1804599231</int>
-																	<int key="NSCellFlags2">4195328</int>
-																	<string key="NSContents"/>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="140016662"/>
-																	<bool key="NSDrawsBackground">YES</bool>
-																	<reference key="NSBackgroundColor" ref="265355499"/>
-																	<reference key="NSTextColor" ref="328927124"/>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSButton" id="367266019">
-																<reference key="NSNextResponder" ref="57587199"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{29, 238}, {404, 19}}</string>
-																<reference key="NSSuperview" ref="57587199"/>
-																<reference key="NSNextKeyView" ref="102143362"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSButtonCell" key="NSCell" id="85520379">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">131072</int>
-																	<string key="NSContents">Insert timestamps in logs</string>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="367266019"/>
-																	<int key="NSButtonFlags">1211912448</int>
-																	<int key="NSButtonFlags2">2</int>
-																	<reference key="NSNormalImage" ref="557231633"/>
-																	<reference key="NSAlternateImage" ref="152492997"/>
-																	<string key="NSAlternateContents"/>
-																	<string key="NSKeyEquivalent"/>
-																	<int key="NSPeriodicDelay">200</int>
-																	<int key="NSPeriodicInterval">25</int>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSButton" id="325970917">
-																<reference key="NSNextResponder" ref="57587199"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{29, 324}, {402, 19}}</string>
-																<reference key="NSSuperview" ref="57587199"/>
-																<reference key="NSNextKeyView" ref="288449918"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSButtonCell" key="NSCell" id="242317460">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">131072</int>
-																	<string key="NSContents">Enable logging of conversations to disk</string>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="325970917"/>
-																	<int key="NSButtonFlags">1211912448</int>
-																	<int key="NSButtonFlags2">2</int>
-																	<reference key="NSNormalImage" ref="557231633"/>
-																	<reference key="NSAlternateImage" ref="152492997"/>
-																	<string key="NSAlternateContents"/>
-																	<string key="NSKeyEquivalent"/>
-																	<int key="NSPeriodicDelay">200</int>
-																	<int key="NSPeriodicInterval">25</int>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSButton" id="506678724">
-																<reference key="NSNextResponder" ref="57587199"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{29, 344}, {400, 19}}</string>
-																<reference key="NSSuperview" ref="57587199"/>
-																<reference key="NSNextKeyView" ref="325970917"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSButtonCell" key="NSCell" id="31633568">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">131072</int>
-																	<string key="NSContents">Display scrollback from previous session</string>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="506678724"/>
-																	<int key="NSButtonFlags">1211912448</int>
-																	<int key="NSButtonFlags2">2</int>
-																	<reference key="NSNormalImage" ref="557231633"/>
-																	<reference key="NSAlternateImage" ref="152492997"/>
-																	<string key="NSAlternateContents"/>
-																	<string key="NSKeyEquivalent"/>
-																	<int key="NSPeriodicDelay">200</int>
-																	<int key="NSPeriodicInterval">25</int>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSTextField" id="755493711">
-																<reference key="NSNextResponder" ref="57587199"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{17, 369}, {415, 17}}</string>
-																<reference key="NSSuperview" ref="57587199"/>
-																<reference key="NSNextKeyView" ref="506678724"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSTextFieldCell" key="NSCell" id="510828702">
-																	<int key="NSCellFlags">68157504</int>
-																	<int key="NSCellFlags2">272630784</int>
-																	<string key="NSContents">Logging</string>
-																	<reference key="NSSupport" ref="218849127"/>
-																	<reference key="NSControlView" ref="755493711"/>
-																	<reference key="NSBackgroundColor" ref="1007130360"/>
-																	<reference key="NSTextColor" ref="725989266"/>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSTextField" id="363290500">
-																<reference key="NSNextResponder" ref="57587199"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{19, 262}, {415, 17}}</string>
-																<reference key="NSSuperview" ref="57587199"/>
-																<reference key="NSNextKeyView" ref="367266019"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSTextFieldCell" key="NSCell" id="114048374">
-																	<int key="NSCellFlags">68157504</int>
-																	<int key="NSCellFlags2">272630784</int>
-																	<string key="NSContents">Time Stamps</string>
-																	<reference key="NSSupport" ref="218849127"/>
-																	<reference key="NSControlView" ref="363290500"/>
-																	<reference key="NSBackgroundColor" ref="1007130360"/>
-																	<reference key="NSTextColor" ref="725989266"/>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSTextField" id="546974449">
-																<reference key="NSNextResponder" ref="57587199"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{192, 287}, {242, 11}}</string>
-																<reference key="NSSuperview" ref="57587199"/>
-																<reference key="NSNextKeyView" ref="363290500"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSTextFieldCell" key="NSCell" id="484063948">
-																	<int key="NSCellFlags">68157504</int>
-																	<int key="NSCellFlags2">272892928</int>
-																	<string key="NSContents">%s=Server %c=Channel %n=Network.</string>
-																	<object class="NSFont" key="NSSupport" id="22">
-																		<string key="NSName">LucidaGrande</string>
-																		<double key="NSSize">9</double>
-																		<int key="NSfFlags">3614</int>
-																	</object>
-																	<reference key="NSControlView" ref="546974449"/>
-																	<reference key="NSBackgroundColor" ref="1007130360"/>
-																	<reference key="NSTextColor" ref="725989266"/>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSTextField" id="555959875">
-																<reference key="NSNextResponder" ref="57587199"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{192, 204}, {240, 11}}</string>
-																<reference key="NSSuperview" ref="57587199"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSTextFieldCell" key="NSCell" id="926272167">
-																	<int key="NSCellFlags">68157504</int>
-																	<int key="NSCellFlags2">272892928</int>
-																	<string key="NSContents">See strftime manpage for details.</string>
-																	<reference key="NSSupport" ref="22"/>
-																	<reference key="NSControlView" ref="555959875"/>
-																	<reference key="NSBackgroundColor" ref="1007130360"/>
-																	<reference key="NSTextColor" ref="725989266"/>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-														</array>
-														<string key="NSFrameSize">{449, 406}</string>
-														<reference key="NSNextKeyView" ref="755493711"/>
-													</object>
-													<reference key="NSColor" ref="1007130360"/>
-													<reference key="NSTabView" ref="1053574686"/>
-												</object>
-												<object class="NSTabViewItem" id="700045870">
-													<object class="NSView" key="NSView" id="208408466">
-														<nil key="NSNextResponder"/>
-														<int key="NSvFlags">256</int>
-														<array class="NSMutableArray" key="NSSubviews">
-															<object class="NSScrollView" id="825536519">
-																<reference key="NSNextResponder" ref="208408466"/>
-																<int key="NSvFlags">274</int>
-																<array class="NSMutableArray" key="NSSubviews">
-																	<object class="NSClipView" id="433990135">
-																		<reference key="NSNextResponder" ref="825536519"/>
-																		<int key="NSvFlags">2304</int>
-																		<array class="NSMutableArray" key="NSSubviews">
-																			<object class="NSTableView" id="932713766">
-																				<reference key="NSNextResponder" ref="433990135"/>
-																				<int key="NSvFlags">256</int>
-																				<string key="NSFrameSize">{407, 296}</string>
-																				<reference key="NSSuperview" ref="433990135"/>
-																				<reference key="NSNextKeyView" ref="470130271"/>
-																				<bool key="NSEnabled">YES</bool>
-																				<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																				<bool key="NSControlAllowsExpansionToolTips">YES</bool>
-																				<object class="NSTableHeaderView" key="NSHeaderView" id="577402709">
-																					<reference key="NSNextResponder" ref="470130271"/>
-																					<int key="NSvFlags">256</int>
-																					<string key="NSFrameSize">{407, 17}</string>
-																					<reference key="NSSuperview" ref="470130271"/>
-																					<reference key="NSNextKeyView" ref="433990135"/>
-																					<reference key="NSTableView" ref="932713766"/>
-																				</object>
-																				<object class="_NSCornerView" key="NSCornerView">
-																					<nil key="NSNextResponder"/>
-																					<int key="NSvFlags">256</int>
-																					<string key="NSFrame">{{393, 0}, {16, 17}}</string>
-																					<reference key="NSNextKeyView" ref="433990135"/>
-																				</object>
-																				<array class="NSMutableArray" key="NSTableColumns">
-																					<object class="NSTableColumn" id="805764618">
-																						<double key="NSWidth">173</double>
-																						<double key="NSMinWidth">40</double>
-																						<double key="NSMaxWidth">1000</double>
-																						<object class="NSTableHeaderCell" key="NSHeaderCell">
-																							<int key="NSCellFlags">75497536</int>
-																							<int key="NSCellFlags2">2048</int>
-																							<string key="NSContents">Event</string>
-																							<reference key="NSSupport" ref="26"/>
-																							<object class="NSColor" key="NSBackgroundColor" id="453432565">
-																								<int key="NSColorSpace">3</int>
-																								<bytes key="NSWhite">MC4zMzMzMzI5ODU2AA</bytes>
-																							</object>
-																							<reference key="NSTextColor" ref="106531208"/>
-																						</object>
-																						<object class="NSTextFieldCell" key="NSDataCell" id="232833055">
-																							<int key="NSCellFlags">338690112</int>
-																							<int key="NSCellFlags2">1024</int>
-																							<reference key="NSSupport" ref="218849127"/>
-																							<reference key="NSControlView" ref="932713766"/>
-																							<reference key="NSBackgroundColor" ref="300919276"/>
-																							<reference key="NSTextColor" ref="725989266"/>
-																						</object>
-																						<int key="NSResizingMask">3</int>
-																						<bool key="NSIsResizeable">YES</bool>
-																						<bool key="NSIsEditable">YES</bool>
-																						<reference key="NSTableView" ref="932713766"/>
-																					</object>
-																					<object class="NSTableColumn" id="514204815">
-																						<double key="NSWidth">134.26999664306641</double>
-																						<double key="NSMinWidth">8</double>
-																						<double key="NSMaxWidth">1000</double>
-																						<object class="NSTableHeaderCell" key="NSHeaderCell">
-																							<int key="NSCellFlags">75497536</int>
-																							<int key="NSCellFlags2">2048</int>
-																							<string key="NSContents">Sound file</string>
-																							<reference key="NSSupport" ref="26"/>
-																							<reference key="NSBackgroundColor" ref="453432565"/>
-																							<reference key="NSTextColor" ref="106531208"/>
-																						</object>
-																						<object class="NSTextFieldCell" key="NSDataCell" id="1048052152">
-																							<int key="NSCellFlags">338690112</int>
-																							<int key="NSCellFlags2">1024</int>
-																							<reference key="NSSupport" ref="218849127"/>
-																							<reference key="NSControlView" ref="932713766"/>
-																							<reference key="NSBackgroundColor" ref="300919276"/>
-																							<reference key="NSTextColor" ref="725989266"/>
-																						</object>
-																						<int key="NSResizingMask">3</int>
-																						<bool key="NSIsResizeable">YES</bool>
-																						<bool key="NSIsEditable">YES</bool>
-																						<reference key="NSTableView" ref="932713766"/>
-																					</object>
-																					<object class="NSTableColumn" id="538257256">
-																						<double key="NSWidth">28</double>
-																						<double key="NSMinWidth">28</double>
-																						<double key="NSMaxWidth">1000</double>
-																						<object class="NSTableHeaderCell" key="NSHeaderCell">
-																							<int key="NSCellFlags">75497536</int>
-																							<int key="NSCellFlags2">134219776</int>
-																							<string key="NSContents">G</string>
-																							<reference key="NSSupport" ref="26"/>
-																							<reference key="NSBackgroundColor" ref="121655387"/>
-																							<reference key="NSTextColor" ref="106531208"/>
-																						</object>
-																						<object class="NSTextFieldCell" key="NSDataCell" id="416647572">
-																							<int key="NSCellFlags">337641536</int>
-																							<int key="NSCellFlags2">134219776</int>
-																							<reference key="NSSupport" ref="218849127"/>
-																							<reference key="NSControlView" ref="932713766"/>
-																							<reference key="NSBackgroundColor" ref="106922994"/>
-																							<reference key="NSTextColor" ref="725989266"/>
-																						</object>
-																						<bool key="NSIsEditable">YES</bool>
-																						<reference key="NSTableView" ref="932713766"/>
-																					</object>
-																					<object class="NSTableColumn" id="855298656">
-																						<double key="NSWidth">28</double>
-																						<double key="NSMinWidth">28</double>
-																						<double key="NSMaxWidth">1000</double>
-																						<object class="NSTableHeaderCell" key="NSHeaderCell">
-																							<int key="NSCellFlags">75497536</int>
-																							<int key="NSCellFlags2">134219776</int>
-																							<string key="NSContents">B</string>
-																							<reference key="NSSupport" ref="26"/>
-																							<reference key="NSBackgroundColor" ref="121655387"/>
-																							<reference key="NSTextColor" ref="106531208"/>
-																						</object>
-																						<object class="NSTextFieldCell" key="NSDataCell" id="405234283">
-																							<int key="NSCellFlags">337641536</int>
-																							<int key="NSCellFlags2">134219776</int>
-																							<reference key="NSSupport" ref="218849127"/>
-																							<reference key="NSControlView" ref="932713766"/>
-																							<reference key="NSBackgroundColor" ref="106922994"/>
-																							<reference key="NSTextColor" ref="725989266"/>
-																						</object>
-																						<bool key="NSIsEditable">YES</bool>
-																						<reference key="NSTableView" ref="932713766"/>
-																					</object>
-																					<object class="NSTableColumn" id="967380251">
-																						<double key="NSWidth">29</double>
-																						<double key="NSMinWidth">28</double>
-																						<double key="NSMaxWidth">1000</double>
-																						<object class="NSTableHeaderCell" key="NSHeaderCell">
-																							<int key="NSCellFlags">75497536</int>
-																							<int key="NSCellFlags2">134219776</int>
-																							<string key="NSContents">S</string>
-																							<reference key="NSSupport" ref="26"/>
-																							<reference key="NSBackgroundColor" ref="121655387"/>
-																							<reference key="NSTextColor" ref="106531208"/>
-																						</object>
-																						<object class="NSTextFieldCell" key="NSDataCell" id="86467400">
-																							<int key="NSCellFlags">337641536</int>
-																							<int key="NSCellFlags2">134219776</int>
-																							<reference key="NSSupport" ref="218849127"/>
-																							<reference key="NSControlView" ref="932713766"/>
-																							<reference key="NSBackgroundColor" ref="106922994"/>
-																							<reference key="NSTextColor" ref="725989266"/>
-																						</object>
-																						<bool key="NSIsEditable">YES</bool>
-																						<reference key="NSTableView" ref="932713766"/>
-																					</object>
-																				</array>
-																				<double key="NSIntercellSpacingWidth">3</double>
-																				<double key="NSIntercellSpacingHeight">2</double>
-																				<reference key="NSBackgroundColor" ref="300919276"/>
-																				<reference key="NSGridColor" ref="88460656"/>
-																				<double key="NSRowHeight">17</double>
-																				<int key="NSTvFlags">-692060160</int>
-																				<reference key="NSDelegate"/>
-																				<reference key="NSDataSource"/>
-																				<int key="NSColumnAutoresizingStyle">4</int>
-																				<int key="NSDraggingSourceMaskForLocal">15</int>
-																				<int key="NSDraggingSourceMaskForNonLocal">0</int>
-																				<bool key="NSAllowsTypeSelect">YES</bool>
-																				<int key="NSTableViewDraggingDestinationStyle">0</int>
-																				<int key="NSTableViewGroupRowStyle">1</int>
-																			</object>
-																		</array>
-																		<string key="NSFrame">{{1, 17}, {407, 296}}</string>
-																		<reference key="NSSuperview" ref="825536519"/>
-																		<reference key="NSNextKeyView" ref="932713766"/>
-																		<reference key="NSDocView" ref="932713766"/>
-																		<reference key="NSBGColor" ref="106922994"/>
-																		<int key="NScvFlags">4</int>
-																	</object>
-																	<object class="NSScroller" id="754821796">
-																		<reference key="NSNextResponder" ref="825536519"/>
-																		<int key="NSvFlags">256</int>
-																		<string key="NSFrame">{{393, 17}, {15, 290}}</string>
-																		<reference key="NSSuperview" ref="825536519"/>
-																		<reference key="NSNextKeyView" ref="281284938"/>
-																		<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																		<reference key="NSTarget" ref="825536519"/>
-																		<string key="NSAction">_doScroller:</string>
-																		<double key="NSPercent">0.99473690986633301</double>
-																	</object>
-																	<object class="NSScroller" id="1011610652">
-																		<reference key="NSNextResponder" ref="825536519"/>
-																		<int key="NSvFlags">256</int>
-																		<string key="NSFrame">{{1, 298}, {401, 15}}</string>
-																		<reference key="NSSuperview" ref="825536519"/>
-																		<reference key="NSNextKeyView" ref="754821796"/>
-																		<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																		<int key="NSsFlags">1</int>
-																		<reference key="NSTarget" ref="825536519"/>
-																		<string key="NSAction">_doScroller:</string>
-																		<double key="NSPercent">0.99240511655807495</double>
-																	</object>
-																	<object class="NSClipView" id="470130271">
-																		<reference key="NSNextResponder" ref="825536519"/>
-																		<int key="NSvFlags">2304</int>
-																		<array class="NSMutableArray" key="NSSubviews">
-																			<reference ref="577402709"/>
-																		</array>
-																		<string key="NSFrame">{{1, 0}, {407, 17}}</string>
-																		<reference key="NSSuperview" ref="825536519"/>
-																		<reference key="NSNextKeyView" ref="577402709"/>
-																		<reference key="NSDocView" ref="577402709"/>
-																		<reference key="NSBGColor" ref="106922994"/>
-																		<int key="NScvFlags">4</int>
-																	</object>
-																</array>
-																<string key="NSFrame">{{20, 70}, {409, 314}}</string>
-																<reference key="NSSuperview" ref="208408466"/>
-																<reference key="NSNextKeyView" ref="433990135"/>
-																<int key="NSsFlags">133170</int>
-																<reference key="NSVScroller" ref="754821796"/>
-																<reference key="NSHScroller" ref="1011610652"/>
-																<reference key="NSContentView" ref="433990135"/>
-																<reference key="NSHeaderClipView" ref="470130271"/>
-																<bytes key="NSScrollAmts">QSAAAEEgAABBmAAAQZgAAA</bytes>
-																<double key="NSMinMagnification">0.25</double>
-																<double key="NSMaxMagnification">4</double>
-																<double key="NSMagnification">1</double>
-															</object>
-															<object class="NSTextField" id="281284938">
-																<reference key="NSNextResponder" ref="208408466"/>
-																<int key="NSvFlags">292</int>
-																<string key="NSFrame">{{17, 49}, {174, 13}}</string>
-																<reference key="NSSuperview" ref="208408466"/>
-																<reference key="NSNextKeyView" ref="500047584"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSTextFieldCell" key="NSCell" id="331744288">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">272629760</int>
-																	<string key="NSContents">G = Show event with Growl</string>
-																	<reference key="NSSupport" ref="309389375"/>
-																	<reference key="NSControlView" ref="281284938"/>
-																	<reference key="NSBackgroundColor" ref="1007130360"/>
-																	<reference key="NSTextColor" ref="725989266"/>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSTextField" id="415497060">
-																<reference key="NSNextResponder" ref="208408466"/>
-																<int key="NSvFlags">292</int>
-																<string key="NSFrame">{{17, 20}, {174, 13}}</string>
-																<reference key="NSSuperview" ref="208408466"/>
-																<reference key="NSNextKeyView" ref="813833386"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSTextFieldCell" key="NSCell" id="376973446">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">272629760</int>
-																	<string key="NSContents">B = Bounce the dock icon</string>
-																	<reference key="NSSupport" ref="309389375"/>
-																	<reference key="NSControlView" ref="415497060"/>
-																	<reference key="NSBackgroundColor" ref="1007130360"/>
-																	<reference key="NSTextColor" ref="725989266"/>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSTextField" id="783182166">
-																<reference key="NSNextResponder" ref="208408466"/>
-																<int key="NSvFlags">292</int>
-																<string key="NSFrame">{{17, 34}, {174, 13}}</string>
-																<reference key="NSSuperview" ref="208408466"/>
-																<reference key="NSNextKeyView" ref="724602615"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSTextFieldCell" key="NSCell" id="947689056">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">272629760</int>
-																	<string key="NSContents">S = Show indicator in the dock</string>
-																	<reference key="NSSupport" ref="309389375"/>
-																	<reference key="NSControlView" ref="783182166"/>
-																	<reference key="NSBackgroundColor" ref="1007130360"/>
-																	<reference key="NSTextColor" ref="725989266"/>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSButton" id="500047584">
-																<reference key="NSNextResponder" ref="208408466"/>
-																<int key="NSvFlags">292</int>
-																<string key="NSFrame">{{185, 48}, {246, 19}}</string>
-																<reference key="NSSuperview" ref="208408466"/>
-																<reference key="NSNextKeyView" ref="783182166"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSButtonCell" key="NSCell" id="298350863">
-																	<int key="NSCellFlags">-1543503872</int>
-																	<int key="NSCellFlags2">262144</int>
-																	<string key="NSContents">Perform when X-Chat Aqua is not in front</string>
-																	<reference key="NSSupport" ref="22"/>
-																	<reference key="NSControlView" ref="500047584"/>
-																	<int key="NSButtonFlags">1211912448</int>
-																	<int key="NSButtonFlags2">2</int>
-																	<reference key="NSNormalImage" ref="557231633"/>
-																	<reference key="NSAlternateImage" ref="152492997"/>
-																	<string key="NSAlternateContents"/>
-																	<string key="NSKeyEquivalent"/>
-																	<int key="NSPeriodicDelay">200</int>
-																	<int key="NSPeriodicInterval">25</int>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSButton" id="724602615">
-																<reference key="NSNextResponder" ref="208408466"/>
-																<int key="NSvFlags">292</int>
-																<string key="NSFrame">{{185, 33}, {246, 19}}</string>
-																<reference key="NSSuperview" ref="208408466"/>
-																<reference key="NSNextKeyView" ref="415497060"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSButtonCell" key="NSCell" id="317990598">
-																	<int key="NSCellFlags">-1543503872</int>
-																	<int key="NSCellFlags2">25427968</int>
-																	<string key="NSContents">Perform always</string>
-																	<reference key="NSSupport" ref="22"/>
-																	<reference key="NSControlView" ref="724602615"/>
-																	<int key="NSButtonFlags">1211912448</int>
-																	<int key="NSButtonFlags2">2</int>
-																	<reference key="NSNormalImage" ref="557231633"/>
-																	<reference key="NSAlternateImage" ref="152492997"/>
-																	<string key="NSAlternateContents"/>
-																	<string key="NSKeyEquivalent"/>
-																	<int key="NSPeriodicDelay">200</int>
-																	<int key="NSPeriodicInterval">25</int>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSButton" id="813833386">
-																<reference key="NSNextResponder" ref="208408466"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{186, 11}, {244, 19}}</string>
-																<reference key="NSSuperview" ref="208408466"/>
-																<string key="NSReuseIdentifierKey">_NS:9</string>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSButtonCell" key="NSCell" id="274140887">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">0</int>
-																	<string key="NSContents">Bounce Continuously</string>
-																	<reference key="NSSupport" ref="218849127"/>
-																	<string key="NSCellIdentifier">_NS:9</string>
-																	<reference key="NSControlView" ref="813833386"/>
-																	<int key="NSButtonFlags">1211912448</int>
-																	<int key="NSButtonFlags2">2</int>
-																	<reference key="NSNormalImage" ref="557231633"/>
-																	<reference key="NSAlternateImage" ref="152492997"/>
-																	<string key="NSAlternateContents"/>
-																	<string key="NSKeyEquivalent"/>
-																	<int key="NSPeriodicDelay">200</int>
-																	<int key="NSPeriodicInterval">25</int>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-														</array>
-														<string key="NSFrameSize">{449, 406}</string>
-														<reference key="NSNextKeyView" ref="825536519"/>
-													</object>
-													<reference key="NSColor" ref="1007130360"/>
-													<reference key="NSTabView" ref="1053574686"/>
-												</object>
-												<object class="NSTabViewItem" id="1069702818">
-													<object class="NSView" key="NSView" id="241887693">
-														<nil key="NSNextResponder"/>
-														<int key="NSvFlags">256</int>
-														<array class="NSMutableArray" key="NSSubviews">
-															<object class="NSTextField" id="719728854">
-																<reference key="NSNextResponder" ref="241887693"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{5, 369}, {415, 17}}</string>
-																<reference key="NSSuperview" ref="241887693"/>
-																<reference key="NSNextKeyView" ref="386977525"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSTextFieldCell" key="NSCell" id="339217709">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">272633856</int>
-																	<string key="NSContents">Advanced Settings</string>
-																	<reference key="NSSupport" ref="60143749"/>
-																	<reference key="NSControlView" ref="719728854"/>
-																	<reference key="NSBackgroundColor" ref="1007130360"/>
-																	<reference key="NSTextColor" ref="725989266"/>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSButton" id="645188295">
-																<reference key="NSNextResponder" ref="241887693"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{17, 323}, {237, 19}}</string>
-																<reference key="NSSuperview" ref="241887693"/>
-																<reference key="NSNextKeyView" ref="400997636"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSButtonCell" key="NSCell" id="583034087">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">131072</int>
-																	<string key="NSContents">Display MODEs in raw form</string>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="645188295"/>
-																	<int key="NSButtonFlags">1211912448</int>
-																	<int key="NSButtonFlags2">2</int>
-																	<reference key="NSNormalImage" ref="557231633"/>
-																	<reference key="NSAlternateImage" ref="152492997"/>
-																	<string key="NSAlternateContents"/>
-																	<string key="NSKeyEquivalent"/>
-																	<int key="NSPeriodicDelay">200</int>
-																	<int key="NSPeriodicInterval">25</int>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSButton" id="400997636">
-																<reference key="NSNextResponder" ref="241887693"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{17, 302}, {231, 19}}</string>
-																<reference key="NSSuperview" ref="241887693"/>
-																<reference key="NSNextKeyView" ref="635477378"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSButtonCell" key="NSCell" id="524145576">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">131072</int>
-																	<string key="NSContents">Whois on notify</string>
-																	<reference key="NSSupport" ref="867044200"/>
-																	<reference key="NSControlView" ref="400997636"/>
-																	<int key="NSButtonFlags">1211912448</int>
-																	<int key="NSButtonFlags2">2</int>
-																	<reference key="NSNormalImage" ref="557231633"/>
-																	<reference key="NSAlternateImage" ref="152492997"/>
-																	<string key="NSAlternateContents"/>
-																	<string key="NSKeyEquivalent"/>
-																	<int key="NSPeriodicDelay">200</int>
-																	<int key="NSPeriodicInterval">25</int>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSButton" id="635477378">
-																<reference key="NSNextResponder" ref="241887693"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{17, 281}, {237, 19}}</string>
-																<reference key="NSSuperview" ref="241887693"/>
-																<reference key="NSNextKeyView" ref="828279874"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSButtonCell" key="NSCell" id="110751444">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">131072</int>
-																	<string key="NSContents">Hide join and part messages</string>
-																	<reference key="NSSupport" ref="867044200"/>
-																	<reference key="NSControlView" ref="635477378"/>
-																	<int key="NSButtonFlags">1211912448</int>
-																	<int key="NSButtonFlags2">2</int>
-																	<reference key="NSNormalImage" ref="557231633"/>
-																	<reference key="NSAlternateImage" ref="152492997"/>
-																	<string key="NSAlternateContents"/>
-																	<string key="NSKeyEquivalent"/>
-																	<int key="NSPeriodicDelay">200</int>
-																	<int key="NSPeriodicInterval">25</int>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSButton" id="386977525">
-																<reference key="NSNextResponder" ref="241887693"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{17, 344}, {220, 19}}</string>
-																<reference key="NSSuperview" ref="241887693"/>
-																<reference key="NSNextKeyView" ref="645188295"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSButtonCell" key="NSCell" id="944772043">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">131072</int>
-																	<string key="NSContents">Automatically rejoin channel</string>
-																	<reference key="NSSupport" ref="867044200"/>
-																	<reference key="NSControlView" ref="386977525"/>
-																	<int key="NSButtonFlags">1211912448</int>
-																	<int key="NSButtonFlags2">2</int>
-																	<reference key="NSNormalImage" ref="557231633"/>
-																	<reference key="NSAlternateImage" ref="152492997"/>
-																	<string key="NSAlternateContents"/>
-																	<string key="NSKeyEquivalent"/>
-																	<int key="NSPeriodicDelay">200</int>
-																	<int key="NSPeriodicInterval">25</int>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSTextField" id="828279874">
-																<reference key="NSNextResponder" ref="241887693"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{5, 258}, {352, 17}}</string>
-																<reference key="NSSuperview" ref="241887693"/>
-																<reference key="NSNextKeyView" ref="592489601"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSTextFieldCell" key="NSCell" id="824455942">
-																	<int key="NSCellFlags">68157504</int>
-																	<int key="NSCellFlags2">272630784</int>
-																	<string key="NSContents">Auto Open DCC Windows</string>
-																	<reference key="NSSupport" ref="60143749"/>
-																	<reference key="NSControlView" ref="828279874"/>
-																	<reference key="NSBackgroundColor" ref="1007130360"/>
-																	<reference key="NSTextColor" ref="725989266"/>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSButton" id="587008753">
-																<reference key="NSNextResponder" ref="241887693"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{17, 212}, {294, 19}}</string>
-																<reference key="NSSuperview" ref="241887693"/>
-																<reference key="NSNextKeyView" ref="602004972"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSButtonCell" key="NSCell" id="117896380">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">131072</int>
-																	<string key="NSContents">Send window</string>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="587008753"/>
-																	<int key="NSButtonFlags">1211912448</int>
-																	<int key="NSButtonFlags2">2</int>
-																	<reference key="NSNormalImage" ref="557231633"/>
-																	<reference key="NSAlternateImage" ref="152492997"/>
-																	<string key="NSAlternateContents"/>
-																	<string key="NSKeyEquivalent"/>
-																	<int key="NSPeriodicDelay">200</int>
-																	<int key="NSPeriodicInterval">25</int>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSButton" id="364692266">
-																<reference key="NSNextResponder" ref="241887693"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{17, 170}, {294, 19}}</string>
-																<reference key="NSSuperview" ref="241887693"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSButtonCell" key="NSCell" id="335421573">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">131072</int>
-																	<string key="NSContents">Chat window</string>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="364692266"/>
-																	<int key="NSButtonFlags">1211912448</int>
-																	<int key="NSButtonFlags2">2</int>
-																	<reference key="NSNormalImage" ref="557231633"/>
-																	<reference key="NSAlternateImage" ref="152492997"/>
-																	<string key="NSAlternateContents"/>
-																	<string key="NSKeyEquivalent"/>
-																	<int key="NSPeriodicDelay">200</int>
-																	<int key="NSPeriodicInterval">25</int>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSButton" id="602004972">
-																<reference key="NSNextResponder" ref="241887693"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{17, 191}, {294, 19}}</string>
-																<reference key="NSSuperview" ref="241887693"/>
-																<reference key="NSNextKeyView" ref="364692266"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSButtonCell" key="NSCell" id="667747744">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">131072</int>
-																	<string key="NSContents">Receive window</string>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="602004972"/>
-																	<int key="NSButtonFlags">1211912448</int>
-																	<int key="NSButtonFlags2">2</int>
-																	<reference key="NSNormalImage" ref="557231633"/>
-																	<reference key="NSAlternateImage" ref="152492997"/>
-																	<string key="NSAlternateContents"/>
-																	<string key="NSKeyEquivalent"/>
-																	<int key="NSPeriodicDelay">200</int>
-																	<int key="NSPeriodicInterval">25</int>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSPopUpButton" id="546931793">
-																<reference key="NSNextResponder" ref="241887693"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{191, 233}, {128, 22}}</string>
-																<reference key="NSSuperview" ref="241887693"/>
-																<reference key="NSNextKeyView" ref="587008753"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSPopUpButtonCell" key="NSCell" id="215407226">
-																	<int key="NSCellFlags">-2076180416</int>
-																	<int key="NSCellFlags2">132096</int>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="546931793"/>
-																	<int key="NSButtonFlags">-2038284288</int>
-																	<int key="NSButtonFlags2">1</int>
-																	<reference key="NSAlternateImage" ref="26"/>
-																	<string key="NSAlternateContents"/>
-																	<object class="NSMutableString" key="NSKeyEquivalent">
-																		<characters key="NS.bytes"/>
-																	</object>
-																	<int key="NSPeriodicDelay">400</int>
-																	<int key="NSPeriodicInterval">75</int>
-																	<object class="NSMenuItem" key="NSMenuItem" id="527276832">
-																		<reference key="NSMenu" ref="1032320442"/>
-																		<string key="NSTitle">Normal</string>
-																		<string key="NSKeyEquiv"/>
-																		<int key="NSKeyEquivModMask">1048576</int>
-																		<int key="NSMnemonicLoc">2147483647</int>
-																		<int key="NSState">1</int>
-																		<reference key="NSOnImage" ref="123016255"/>
-																		<reference key="NSMixedImage" ref="138212614"/>
-																		<string key="NSAction">_popUpItemAction:</string>
-																		<reference key="NSTarget" ref="215407226"/>
-																	</object>
-																	<bool key="NSMenuItemRespectAlignment">YES</bool>
-																	<object class="NSMenu" key="NSMenu" id="1032320442">
-																		<string key="NSTitle"/>
-																		<array class="NSMutableArray" key="NSMenuItems">
-																			<reference ref="527276832"/>
-																			<object class="NSMenuItem" id="478326210">
-																				<reference key="NSMenu" ref="1032320442"/>
-																				<string key="NSTitle">Auto Accept</string>
-																				<string key="NSKeyEquiv"/>
-																				<int key="NSKeyEquivModMask">1048576</int>
-																				<int key="NSMnemonicLoc">2147483647</int>
-																				<reference key="NSOnImage" ref="123016255"/>
-																				<reference key="NSMixedImage" ref="138212614"/>
-																				<string key="NSAction">_popUpItemAction:</string>
-																				<reference key="NSTarget" ref="215407226"/>
-																			</object>
-																			<object class="NSMenuItem" id="206515966">
-																				<reference key="NSMenu" ref="1032320442"/>
-																				<string key="NSTitle">Ask me</string>
-																				<string key="NSKeyEquiv"/>
-																				<int key="NSKeyEquivModMask">1048576</int>
-																				<int key="NSMnemonicLoc">2147483647</int>
-																				<reference key="NSOnImage" ref="123016255"/>
-																				<reference key="NSMixedImage" ref="138212614"/>
-																				<string key="NSAction">_popUpItemAction:</string>
-																				<reference key="NSTarget" ref="215407226"/>
-																			</object>
-																		</array>
-																	</object>
-																	<int key="NSPreferredEdge">3</int>
-																	<bool key="NSUsesItemFromMenu">YES</bool>
-																	<bool key="NSAltersState">YES</bool>
-																	<int key="NSArrowPosition">1</int>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSTextField" id="592489601">
-																<reference key="NSNextResponder" ref="241887693"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{12, 235}, {177, 17}}</string>
-																<reference key="NSSuperview" ref="241887693"/>
-																<reference key="NSNextKeyView" ref="546931793"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSTextFieldCell" key="NSCell" id="905422449">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">71303168</int>
-																	<string key="NSContents">DCC Chat Action</string>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="592489601"/>
-																	<reference key="NSBackgroundColor" ref="1007130360"/>
-																	<reference key="NSTextColor" ref="725989266"/>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-														</array>
-														<string key="NSFrameSize">{449, 406}</string>
-														<reference key="NSNextKeyView" ref="719728854"/>
-													</object>
-													<reference key="NSColor" ref="1007130360"/>
-													<reference key="NSTabView" ref="1053574686"/>
-												</object>
-												<object class="NSTabViewItem" id="410501168">
-													<object class="NSView" key="NSView" id="131199459">
-														<nil key="NSNextResponder"/>
-														<int key="NSvFlags">256</int>
-														<array class="NSMutableArray" key="NSSubviews">
-															<object class="NSTextField" id="14999216">
-																<reference key="NSNextResponder" ref="131199459"/>
-																<int key="NSvFlags">266</int>
-																<string key="NSFrame">{{141, 345}, {288, 19}}</string>
-																<reference key="NSSuperview" ref="131199459"/>
-																<reference key="NSNextKeyView" ref="787415205"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSTextFieldCell" key="NSCell" id="419343362">
-																	<int key="NSCellFlags">-1804599231</int>
-																	<int key="NSCellFlags2">4195328</int>
-																	<string key="NSContents"/>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="14999216"/>
-																	<bool key="NSDrawsBackground">YES</bool>
-																	<reference key="NSBackgroundColor" ref="265355499"/>
-																	<reference key="NSTextColor" ref="328927124"/>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSTextField" id="182242525">
-																<reference key="NSNextResponder" ref="131199459"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{15, 348}, {121, 14}}</string>
-																<reference key="NSSuperview" ref="131199459"/>
-																<reference key="NSNextKeyView" ref="922446711"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSTextFieldCell" key="NSCell" id="598158509">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">71303168</int>
-																	<string key="NSContents">Bind to:</string>
-																	<reference key="NSSupport" ref="867044200"/>
-																	<reference key="NSControlView" ref="182242525"/>
-																	<reference key="NSBackgroundColor" ref="1007130360"/>
-																	<reference key="NSTextColor" ref="725989266"/>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSTextField" id="922446711">
-																<reference key="NSNextResponder" ref="131199459"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{17, 329}, {415, 17}}</string>
-																<reference key="NSSuperview" ref="131199459"/>
-																<reference key="NSNextKeyView" ref="14999216"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSTextFieldCell" key="NSCell" id="27860998">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">71434240</int>
-																	<string key="NSContents">Only useful for computers with multiple addresses.</string>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="922446711"/>
-																	<reference key="NSBackgroundColor" ref="1007130360"/>
-																	<reference key="NSTextColor" ref="725989266"/>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSTextField" id="576326782">
-																<reference key="NSNextResponder" ref="131199459"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{17, 292}, {119, 17}}</string>
-																<reference key="NSSuperview" ref="131199459"/>
-																<reference key="NSNextKeyView" ref="687146077"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSTextFieldCell" key="NSCell" id="415439001">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">71303168</int>
-																	<string key="NSContents">Hostname:</string>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="576326782"/>
-																	<reference key="NSBackgroundColor" ref="1007130360"/>
-																	<reference key="NSTextColor" ref="725989266"/>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSTextField" id="787415205">
-																<reference key="NSNextResponder" ref="131199459"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{17, 320}, {415, 17}}</string>
-																<reference key="NSSuperview" ref="131199459"/>
-																<reference key="NSNextKeyView" ref="576326782"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSTextFieldCell" key="NSCell" id="1067897035">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">4194304</int>
-																	<string key="NSContents">Proxy Server</string>
-																	<reference key="NSSupport" ref="60143749"/>
-																	<reference key="NSControlView" ref="787415205"/>
-																	<reference key="NSBackgroundColor" ref="1007130360"/>
-																	<reference key="NSTextColor" ref="725989266"/>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSTextField" id="858794840">
-																<reference key="NSNextResponder" ref="131199459"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{17, 191}, {415, 17}}</string>
-																<reference key="NSSuperview" ref="131199459"/>
-																<reference key="NSNextKeyView" ref="887471351"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSTextFieldCell" key="NSCell" id="144903932">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">4194304</int>
-																	<string key="NSContents">Proxy Authentication</string>
-																	<reference key="NSSupport" ref="60143749"/>
-																	<reference key="NSControlView" ref="858794840"/>
-																	<reference key="NSBackgroundColor" ref="1007130360"/>
-																	<reference key="NSTextColor" ref="725989266"/>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSTextField" id="475001756">
-																<reference key="NSNextResponder" ref="131199459"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{17, 88}, {415, 17}}</string>
-																<reference key="NSSuperview" ref="131199459"/>
-																<reference key="NSNextKeyView" ref="422271573"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSTextFieldCell" key="NSCell" id="32408489">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">4194304</int>
-																	<string key="NSContents">Other</string>
-																	<reference key="NSSupport" ref="60143749"/>
-																	<reference key="NSControlView" ref="475001756"/>
-																	<reference key="NSBackgroundColor" ref="1007130360"/>
-																	<reference key="NSTextColor" ref="725989266"/>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSTextField" id="533989164">
-																<reference key="NSNextResponder" ref="131199459"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{17, 369}, {415, 17}}</string>
-																<reference key="NSSuperview" ref="131199459"/>
-																<reference key="NSNextKeyView" ref="182242525"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSTextFieldCell" key="NSCell" id="885713094">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">4194304</int>
-																	<string key="NSContents">Your Address</string>
-																	<reference key="NSSupport" ref="60143749"/>
-																	<reference key="NSControlView" ref="533989164"/>
-																	<reference key="NSBackgroundColor" ref="1007130360"/>
-																	<reference key="NSTextColor" ref="725989266"/>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSTextField" id="687146077">
-																<reference key="NSNextResponder" ref="131199459"/>
-																<int key="NSvFlags">266</int>
-																<string key="NSFrame">{{141, 293}, {288, 19}}</string>
-																<reference key="NSSuperview" ref="131199459"/>
-																<reference key="NSNextKeyView" ref="1054086864"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSTextFieldCell" key="NSCell" id="243539596">
-																	<int key="NSCellFlags">-1804599231</int>
-																	<int key="NSCellFlags2">4195328</int>
-																	<string key="NSContents"/>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="687146077"/>
-																	<bool key="NSDrawsBackground">YES</bool>
-																	<reference key="NSBackgroundColor" ref="265355499"/>
-																	<reference key="NSTextColor" ref="328927124"/>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSTextField" id="241602288">
-																<reference key="NSNextResponder" ref="131199459"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{17, 140}, {119, 17}}</string>
-																<reference key="NSSuperview" ref="131199459"/>
-																<reference key="NSNextKeyView" ref="823414242"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSTextFieldCell" key="NSCell" id="493118706">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">71303168</int>
-																	<string key="NSContents">Username:</string>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="241602288"/>
-																	<reference key="NSBackgroundColor" ref="1007130360"/>
-																	<reference key="NSTextColor" ref="725989266"/>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSTextField" id="823414242">
-																<reference key="NSNextResponder" ref="131199459"/>
-																<int key="NSvFlags">266</int>
-																<string key="NSFrame">{{141, 141}, {288, 19}}</string>
-																<reference key="NSSuperview" ref="131199459"/>
-																<reference key="NSNextKeyView" ref="1048498102"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSTextFieldCell" key="NSCell" id="1003697772">
-																	<int key="NSCellFlags">-1804599231</int>
-																	<int key="NSCellFlags2">4195328</int>
-																	<string key="NSContents"/>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="823414242"/>
-																	<bool key="NSDrawsBackground">YES</bool>
-																	<reference key="NSBackgroundColor" ref="265355499"/>
-																	<reference key="NSTextColor" ref="328927124"/>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSTextField" id="1054086864">
-																<reference key="NSNextResponder" ref="131199459"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{17, 265}, {119, 17}}</string>
-																<reference key="NSSuperview" ref="131199459"/>
-																<reference key="NSNextKeyView" ref="975592998"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSTextFieldCell" key="NSCell" id="63375091">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">71303168</int>
-																	<string key="NSContents">Port:</string>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="1054086864"/>
-																	<reference key="NSBackgroundColor" ref="1007130360"/>
-																	<reference key="NSTextColor" ref="725989266"/>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSTextField" id="633912981">
-																<reference key="NSNextResponder" ref="131199459"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{17, 240}, {119, 17}}</string>
-																<reference key="NSSuperview" ref="131199459"/>
-																<reference key="NSNextKeyView" ref="291755447"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSTextFieldCell" key="NSCell" id="673395531">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">71303168</int>
-																	<string key="NSContents">Type:</string>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="633912981"/>
-																	<reference key="NSBackgroundColor" ref="1007130360"/>
-																	<reference key="NSTextColor" ref="725989266"/>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSTextField" id="975592998">
-																<reference key="NSNextResponder" ref="131199459"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{141, 266}, {48, 19}}</string>
-																<reference key="NSSuperview" ref="131199459"/>
-																<reference key="NSNextKeyView" ref="633912981"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSTextFieldCell" key="NSCell" id="254322774">
-																	<int key="NSCellFlags">-1804599231</int>
-																	<int key="NSCellFlags2">4195328</int>
-																	<string key="NSContents"/>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="975592998"/>
-																	<bool key="NSDrawsBackground">YES</bool>
-																	<reference key="NSBackgroundColor" ref="265355499"/>
-																	<reference key="NSTextColor" ref="328927124"/>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSPopUpButton" id="291755447">
-																<reference key="NSNextResponder" ref="131199459"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{138, 237}, {146, 22}}</string>
-																<reference key="NSSuperview" ref="131199459"/>
-																<reference key="NSNextKeyView" ref="255235135"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSPopUpButtonCell" key="NSCell" id="41867835">
-																	<int key="NSCellFlags">-2076180416</int>
-																	<int key="NSCellFlags2">132096</int>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="291755447"/>
-																	<int key="NSButtonFlags">109199360</int>
-																	<int key="NSButtonFlags2">1</int>
-																	<reference key="NSAlternateImage" ref="26"/>
-																	<object class="NSMutableString" key="NSAlternateContents">
-																		<characters key="NS.bytes"/>
-																	</object>
-																	<object class="NSMutableString" key="NSKeyEquivalent">
-																		<characters key="NS.bytes"/>
-																	</object>
-																	<int key="NSPeriodicDelay">400</int>
-																	<int key="NSPeriodicInterval">75</int>
-																	<object class="NSMenuItem" key="NSMenuItem" id="659020466">
-																		<reference key="NSMenu" ref="736055343"/>
-																		<string key="NSTitle">(Disabled)</string>
-																		<string key="NSKeyEquiv"/>
-																		<int key="NSKeyEquivModMask">1048576</int>
-																		<int key="NSMnemonicLoc">2147483647</int>
-																		<int key="NSState">1</int>
-																		<reference key="NSOnImage" ref="123016255"/>
-																		<reference key="NSMixedImage" ref="138212614"/>
-																		<string key="NSAction">_popUpItemAction:</string>
-																		<reference key="NSTarget" ref="41867835"/>
-																	</object>
-																	<bool key="NSMenuItemRespectAlignment">YES</bool>
-																	<object class="NSMenu" key="NSMenu" id="736055343">
-																		<string key="NSTitle"/>
-																		<array class="NSMutableArray" key="NSMenuItems">
-																			<reference ref="659020466"/>
-																			<object class="NSMenuItem" id="152202287">
-																				<reference key="NSMenu" ref="736055343"/>
-																				<string key="NSTitle">Wingate</string>
-																				<string key="NSKeyEquiv"/>
-																				<int key="NSKeyEquivModMask">1048576</int>
-																				<int key="NSMnemonicLoc">2147483647</int>
-																				<reference key="NSOnImage" ref="123016255"/>
-																				<reference key="NSMixedImage" ref="138212614"/>
-																				<string key="NSAction">_popUpItemAction:</string>
-																				<reference key="NSTarget" ref="41867835"/>
-																			</object>
-																			<object class="NSMenuItem" id="418675757">
-																				<reference key="NSMenu" ref="736055343"/>
-																				<string key="NSTitle">Socks4</string>
-																				<string key="NSKeyEquiv"/>
-																				<int key="NSKeyEquivModMask">1048576</int>
-																				<int key="NSMnemonicLoc">2147483647</int>
-																				<reference key="NSOnImage" ref="123016255"/>
-																				<reference key="NSMixedImage" ref="138212614"/>
-																				<string key="NSAction">_popUpItemAction:</string>
-																				<reference key="NSTarget" ref="41867835"/>
-																			</object>
-																			<object class="NSMenuItem" id="40846141">
-																				<reference key="NSMenu" ref="736055343"/>
-																				<string key="NSTitle">Socks5</string>
-																				<string key="NSKeyEquiv"/>
-																				<int key="NSKeyEquivModMask">1048576</int>
-																				<int key="NSMnemonicLoc">2147483647</int>
-																				<reference key="NSOnImage" ref="123016255"/>
-																				<reference key="NSMixedImage" ref="138212614"/>
-																				<string key="NSAction">_popUpItemAction:</string>
-																				<reference key="NSTarget" ref="41867835"/>
-																			</object>
-																			<object class="NSMenuItem" id="562311160">
-																				<reference key="NSMenu" ref="736055343"/>
-																				<string key="NSTitle">HTTP</string>
-																				<string key="NSKeyEquiv"/>
-																				<int key="NSKeyEquivModMask">1048576</int>
-																				<int key="NSMnemonicLoc">2147483647</int>
-																				<reference key="NSOnImage" ref="123016255"/>
-																				<reference key="NSMixedImage" ref="138212614"/>
-																				<string key="NSAction">_popUpItemAction:</string>
-																				<reference key="NSTarget" ref="41867835"/>
-																			</object>
-																		</array>
-																	</object>
-																	<int key="NSPreferredEdge">3</int>
-																	<bool key="NSUsesItemFromMenu">YES</bool>
-																	<bool key="NSAltersState">YES</bool>
-																	<int key="NSArrowPosition">1</int>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSTextField" id="255235135">
-																<reference key="NSNextResponder" ref="131199459"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{17, 216}, {119, 17}}</string>
-																<reference key="NSSuperview" ref="131199459"/>
-																<reference key="NSNextKeyView" ref="199654805"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSTextFieldCell" key="NSCell" id="438880081">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">71303168</int>
-																	<string key="NSContents">Use proxy for:</string>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="255235135"/>
-																	<reference key="NSBackgroundColor" ref="1007130360"/>
-																	<reference key="NSTextColor" ref="725989266"/>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSPopUpButton" id="199654805">
-																<reference key="NSNextResponder" ref="131199459"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{138, 212}, {146, 22}}</string>
-																<reference key="NSSuperview" ref="131199459"/>
-																<reference key="NSNextKeyView" ref="858794840"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSPopUpButtonCell" key="NSCell" id="167413563">
-																	<int key="NSCellFlags">-2076180416</int>
-																	<int key="NSCellFlags2">132096</int>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="199654805"/>
-																	<int key="NSButtonFlags">109199360</int>
-																	<int key="NSButtonFlags2">1</int>
-																	<reference key="NSAlternateImage" ref="26"/>
-																	<object class="NSMutableString" key="NSAlternateContents">
-																		<characters key="NS.bytes"/>
-																	</object>
-																	<object class="NSMutableString" key="NSKeyEquivalent">
-																		<characters key="NS.bytes"/>
-																	</object>
-																	<int key="NSPeriodicDelay">400</int>
-																	<int key="NSPeriodicInterval">75</int>
-																	<object class="NSMenuItem" key="NSMenuItem" id="653582089">
-																		<reference key="NSMenu" ref="915719007"/>
-																		<string key="NSTitle">All Connections</string>
-																		<string key="NSKeyEquiv"/>
-																		<int key="NSKeyEquivModMask">1048576</int>
-																		<int key="NSMnemonicLoc">2147483647</int>
-																		<int key="NSState">1</int>
-																		<reference key="NSOnImage" ref="123016255"/>
-																		<reference key="NSMixedImage" ref="138212614"/>
-																		<string key="NSAction">_popUpItemAction:</string>
-																		<reference key="NSTarget" ref="167413563"/>
-																	</object>
-																	<bool key="NSMenuItemRespectAlignment">YES</bool>
-																	<object class="NSMenu" key="NSMenu" id="915719007">
-																		<string key="NSTitle"/>
-																		<array class="NSMutableArray" key="NSMenuItems">
-																			<reference ref="653582089"/>
-																			<object class="NSMenuItem" id="1060181807">
-																				<reference key="NSMenu" ref="915719007"/>
-																				<string key="NSTitle">IRC Server Only</string>
-																				<string key="NSKeyEquiv"/>
-																				<int key="NSKeyEquivModMask">1048576</int>
-																				<int key="NSMnemonicLoc">2147483647</int>
-																				<reference key="NSOnImage" ref="123016255"/>
-																				<reference key="NSMixedImage" ref="138212614"/>
-																				<string key="NSAction">_popUpItemAction:</string>
-																				<reference key="NSTarget" ref="167413563"/>
-																			</object>
-																			<object class="NSMenuItem" id="1051492125">
-																				<reference key="NSMenu" ref="915719007"/>
-																				<string key="NSTitle">DCC Get Only</string>
-																				<string key="NSKeyEquiv"/>
-																				<int key="NSKeyEquivModMask">1048576</int>
-																				<int key="NSMnemonicLoc">2147483647</int>
-																				<reference key="NSOnImage" ref="123016255"/>
-																				<reference key="NSMixedImage" ref="138212614"/>
-																				<string key="NSAction">_popUpItemAction:</string>
-																				<reference key="NSTarget" ref="167413563"/>
-																			</object>
-																		</array>
-																	</object>
-																	<int key="NSPreferredEdge">3</int>
-																	<bool key="NSUsesItemFromMenu">YES</bool>
-																	<bool key="NSAltersState">YES</bool>
-																	<int key="NSArrowPosition">1</int>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSButton" id="1062025260">
-																<reference key="NSNextResponder" ref="131199459"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{27, 19}, {402, 19}}</string>
-																<reference key="NSSuperview" ref="131199459"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSButtonCell" key="NSCell" id="227305221">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">131072</int>
-																	<string key="NSContents">Enable built-in identd (requires administrator privileges)</string>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="1062025260"/>
-																	<int key="NSButtonFlags">1211912448</int>
-																	<int key="NSButtonFlags2">2</int>
-																	<reference key="NSNormalImage" ref="557231633"/>
-																	<reference key="NSAlternateImage" ref="152492997"/>
-																	<string key="NSAlternateContents"/>
-																	<string key="NSKeyEquivalent"/>
-																	<int key="NSPeriodicDelay">200</int>
-																	<int key="NSPeriodicInterval">25</int>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSTextField" id="250273303">
-																<reference key="NSNextResponder" ref="131199459"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{309, 63}, {121, 14}}</string>
-																<reference key="NSSuperview" ref="131199459"/>
-																<reference key="NSNextKeyView" ref="720402574"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSTextFieldCell" key="NSCell" id="1043349204">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">4194304</int>
-																	<string key="NSContents">seconds</string>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="250273303"/>
-																	<reference key="NSBackgroundColor" ref="1007130360"/>
-																	<reference key="NSTextColor" ref="725989266"/>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSTextField" id="410813163">
-																<reference key="NSNextResponder" ref="131199459"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{257, 61}, {47, 19}}</string>
-																<reference key="NSSuperview" ref="131199459"/>
-																<reference key="NSNextKeyView" ref="250273303"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSTextFieldCell" key="NSCell" id="173122541">
-																	<int key="NSCellFlags">-1804599231</int>
-																	<int key="NSCellFlags2">4195328</int>
-																	<string key="NSContents"/>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="410813163"/>
-																	<bool key="NSDrawsBackground">YES</bool>
-																	<reference key="NSBackgroundColor" ref="265355499"/>
-																	<reference key="NSTextColor" ref="328927124"/>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSButton" id="422271573">
-																<reference key="NSNextResponder" ref="131199459"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{27, 61}, {224, 19}}</string>
-																<reference key="NSSuperview" ref="131199459"/>
-																<reference key="NSNextKeyView" ref="410813163"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSButtonCell" key="NSCell" id="834827122">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">131072</int>
-																	<string key="NSContents">Auto reconnect to server after</string>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="422271573"/>
-																	<int key="NSButtonFlags">1211912448</int>
-																	<int key="NSButtonFlags2">2</int>
-																	<reference key="NSNormalImage" ref="557231633"/>
-																	<reference key="NSAlternateImage" ref="152492997"/>
-																	<string key="NSAlternateContents"/>
-																	<string key="NSKeyEquivalent"/>
-																	<int key="NSPeriodicDelay">200</int>
-																	<int key="NSPeriodicInterval">25</int>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSButton" id="887471351">
-																<reference key="NSNextResponder" ref="131199459"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{29, 166}, {299, 19}}</string>
-																<reference key="NSSuperview" ref="131199459"/>
-																<reference key="NSNextKeyView" ref="241602288"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSButtonCell" key="NSCell" id="939905285">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">131072</int>
-																	<string key="NSContents">Use Authentication (HTTP or Socks5 only)</string>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="887471351"/>
-																	<int key="NSButtonFlags">1211912448</int>
-																	<int key="NSButtonFlags2">2</int>
-																	<reference key="NSNormalImage" ref="557231633"/>
-																	<reference key="NSAlternateImage" ref="152492997"/>
-																	<string key="NSAlternateContents"/>
-																	<string key="NSKeyEquivalent"/>
-																	<int key="NSPeriodicDelay">200</int>
-																	<int key="NSPeriodicInterval">25</int>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSButton" id="720402574">
-																<reference key="NSNextResponder" ref="131199459"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{27, 40}, {402, 19}}</string>
-																<reference key="NSSuperview" ref="131199459"/>
-																<reference key="NSNextKeyView" ref="1062025260"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSButtonCell" key="NSCell" id="806919615">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">131072</int>
-																	<string key="NSContents">Never give up reconnect</string>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="720402574"/>
-																	<int key="NSButtonFlags">1211912448</int>
-																	<int key="NSButtonFlags2">2</int>
-																	<reference key="NSNormalImage" ref="557231633"/>
-																	<reference key="NSAlternateImage" ref="152492997"/>
-																	<string key="NSAlternateContents"/>
-																	<string key="NSKeyEquivalent"/>
-																	<int key="NSPeriodicDelay">200</int>
-																	<int key="NSPeriodicInterval">25</int>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSTextField" id="1048498102">
-																<reference key="NSNextResponder" ref="131199459"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{17, 112}, {119, 17}}</string>
-																<reference key="NSSuperview" ref="131199459"/>
-																<reference key="NSNextKeyView" ref="317149642"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSTextFieldCell" key="NSCell" id="107763750">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">71303168</int>
-																	<string key="NSContents">Password:</string>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="1048498102"/>
-																	<reference key="NSBackgroundColor" ref="1007130360"/>
-																	<reference key="NSTextColor" ref="725989266"/>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSTextField" id="317149642">
-																<reference key="NSNextResponder" ref="131199459"/>
-																<int key="NSvFlags">266</int>
-																<string key="NSFrame">{{141, 113}, {288, 19}}</string>
-																<reference key="NSSuperview" ref="131199459"/>
-																<reference key="NSNextKeyView" ref="475001756"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSTextFieldCell" key="NSCell" id="242789126">
-																	<int key="NSCellFlags">-1804599231</int>
-																	<int key="NSCellFlags2">4195328</int>
-																	<string key="NSContents"/>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="317149642"/>
-																	<bool key="NSDrawsBackground">YES</bool>
-																	<reference key="NSBackgroundColor" ref="265355499"/>
-																	<reference key="NSTextColor" ref="328927124"/>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-														</array>
-														<string key="NSFrameSize">{449, 406}</string>
-														<reference key="NSNextKeyView" ref="533989164"/>
-													</object>
-													<reference key="NSColor" ref="1007130360"/>
-													<reference key="NSTabView" ref="1053574686"/>
-												</object>
-												<object class="NSTabViewItem" id="82298705">
-													<object class="NSView" key="NSView" id="528799783">
-														<nil key="NSNextResponder"/>
-														<int key="NSvFlags">256</int>
-														<array class="NSMutableArray" key="NSSubviews">
-															<object class="NSTextField" id="100091316">
-																<reference key="NSNextResponder" ref="528799783"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{17, 192}, {177, 17}}</string>
-																<reference key="NSSuperview" ref="528799783"/>
-																<reference key="NSNextKeyView" ref="617259440"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSTextFieldCell" key="NSCell" id="33394425">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">71303168</int>
-																	<string key="NSContents">First DCC send port:</string>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="100091316"/>
-																	<reference key="NSBackgroundColor" ref="1007130360"/>
-																	<reference key="NSTextColor" ref="725989266"/>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSTextField" id="391437494">
-																<reference key="NSNextResponder" ref="528799783"/>
-																<int key="NSvFlags">266</int>
-																<string key="NSFrame">{{199, 220}, {230, 19}}</string>
-																<reference key="NSSuperview" ref="528799783"/>
-																<reference key="NSNextKeyView" ref="100091316"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSTextFieldCell" key="NSCell" id="433742716">
-																	<int key="NSCellFlags">-1804599231</int>
-																	<int key="NSCellFlags2">4195328</int>
-																	<string key="NSContents"/>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="391437494"/>
-																	<bool key="NSDrawsBackground">YES</bool>
-																	<reference key="NSBackgroundColor" ref="265355499"/>
-																	<reference key="NSTextColor" ref="328927124"/>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSTextField" id="617259440">
-																<reference key="NSNextResponder" ref="528799783"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{199, 192}, {44, 19}}</string>
-																<reference key="NSSuperview" ref="528799783"/>
-																<reference key="NSNextKeyView" ref="615357857"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSTextFieldCell" key="NSCell" id="416222473">
-																	<int key="NSCellFlags">-1804599231</int>
-																	<int key="NSCellFlags2">4195328</int>
-																	<string key="NSContents">0</string>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="617259440"/>
-																	<bool key="NSDrawsBackground">YES</bool>
-																	<reference key="NSBackgroundColor" ref="265355499"/>
-																	<reference key="NSTextColor" ref="328927124"/>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSTextField" id="677491028">
-																<reference key="NSNextResponder" ref="528799783"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{17, 222}, {177, 14}}</string>
-																<reference key="NSSuperview" ref="528799783"/>
-																<reference key="NSNextKeyView" ref="391437494"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSTextFieldCell" key="NSCell" id="1002348628">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">71303168</int>
-																	<string key="NSContents">DCC IP address:</string>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="677491028"/>
-																	<reference key="NSBackgroundColor" ref="1007130360"/>
-																	<reference key="NSTextColor" ref="725989266"/>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSTextField" id="879421054">
-																<reference key="NSNextResponder" ref="528799783"/>
-																<int key="NSvFlags">-2147483382</int>
-																<string key="NSFrame">{{199, 318}, {230, 19}}</string>
-																<reference key="NSSuperview" ref="528799783"/>
-																<reference key="NSNextKeyView" ref="409395540"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSTextFieldCell" key="NSCell" id="779276659">
-																	<int key="NSCellFlags">-1804599231</int>
-																	<int key="NSCellFlags2">4195328</int>
-																	<string key="NSContents"/>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="879421054"/>
-																	<bool key="NSDrawsBackground">YES</bool>
-																	<reference key="NSBackgroundColor" ref="265355499"/>
-																	<reference key="NSTextColor" ref="328927124"/>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSTextField" id="298337413">
-																<reference key="NSNextResponder" ref="528799783"/>
-																<int key="NSvFlags">-2147483380</int>
-																<string key="NSFrame">{{5, 320}, {189, 14}}</string>
-																<reference key="NSSuperview" ref="528799783"/>
-																<reference key="NSNextKeyView" ref="879421054"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSTextFieldCell" key="NSCell" id="19692194">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">71303168</int>
-																	<string key="NSContents">Download files to:</string>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="298337413"/>
-																	<reference key="NSBackgroundColor" ref="1007130360"/>
-																	<reference key="NSTextColor" ref="725989266"/>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSTextField" id="615357857">
-																<reference key="NSNextResponder" ref="528799783"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{17, 168}, {177, 14}}</string>
-																<reference key="NSSuperview" ref="528799783"/>
-																<reference key="NSNextKeyView" ref="86962169"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSTextFieldCell" key="NSCell" id="58983848">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">71303168</int>
-																	<string key="NSContents">Last DCC send port:</string>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="615357857"/>
-																	<reference key="NSBackgroundColor" ref="1007130360"/>
-																	<reference key="NSTextColor" ref="725989266"/>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSTextField" id="86962169">
-																<reference key="NSNextResponder" ref="528799783"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{199, 165}, {44, 19}}</string>
-																<reference key="NSSuperview" ref="528799783"/>
-																<reference key="NSNextKeyView" ref="724103728"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSTextFieldCell" key="NSCell" id="223140313">
-																	<int key="NSCellFlags">-1804599231</int>
-																	<int key="NSCellFlags2">4195328</int>
-																	<string key="NSContents">0</string>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="86962169"/>
-																	<bool key="NSDrawsBackground">YES</bool>
-																	<reference key="NSBackgroundColor" ref="265355499"/>
-																	<reference key="NSTextColor" ref="328927124"/>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSButton" id="713833474">
-																<reference key="NSNextResponder" ref="528799783"/>
-																<int key="NSvFlags">270</int>
-																<string key="NSFrame">{{29, 292}, {195, 19}}</string>
-																<reference key="NSSuperview" ref="528799783"/>
-																<reference key="NSNextKeyView" ref="324798199"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSButtonCell" key="NSCell" id="208818602">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">131072</int>
-																	<string key="NSContents">Save nick name in filenames</string>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="713833474"/>
-																	<int key="NSButtonFlags">1211912448</int>
-																	<int key="NSButtonFlags2">2</int>
-																	<reference key="NSNormalImage" ref="557231633"/>
-																	<reference key="NSAlternateImage" ref="152492997"/>
-																	<string key="NSAlternateContents"/>
-																	<string key="NSKeyEquivalent"/>
-																	<int key="NSPeriodicDelay">200</int>
-																	<int key="NSPeriodicInterval">25</int>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSButton" id="324798199">
-																<reference key="NSNextResponder" ref="528799783"/>
-																<int key="NSvFlags">267</int>
-																<string key="NSFrame">{{236, 292}, {195, 19}}</string>
-																<reference key="NSSuperview" ref="528799783"/>
-																<reference key="NSNextKeyView" ref="536293017"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSButtonCell" key="NSCell" id="286514404">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">131072</int>
-																	<string key="NSContents">Convert spaces to underscore</string>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="324798199"/>
-																	<int key="NSButtonFlags">1211912448</int>
-																	<int key="NSButtonFlags2">2</int>
-																	<reference key="NSNormalImage" ref="557231633"/>
-																	<reference key="NSAlternateImage" ref="152492997"/>
-																	<string key="NSAlternateContents"/>
-																	<string key="NSKeyEquivalent"/>
-																	<int key="NSPeriodicDelay">200</int>
-																	<int key="NSPeriodicInterval">25</int>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSButton" id="455996658">
-																<reference key="NSNextResponder" ref="528799783"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{29, 245}, {222, 19}}</string>
-																<reference key="NSSuperview" ref="528799783"/>
-																<reference key="NSNextKeyView" ref="677491028"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSButtonCell" key="NSCell" id="284754102">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">131072</int>
-																	<string key="NSContents">Get my address from the IRC server</string>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="455996658"/>
-																	<int key="NSButtonFlags">1211912448</int>
-																	<int key="NSButtonFlags2">2</int>
-																	<reference key="NSNormalImage" ref="557231633"/>
-																	<reference key="NSAlternateImage" ref="152492997"/>
-																	<string key="NSAlternateContents"/>
-																	<string key="NSKeyEquivalent"/>
-																	<int key="NSPeriodicDelay">200</int>
-																	<int key="NSPeriodicInterval">25</int>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSTextField" id="117258399">
-																<reference key="NSNextResponder" ref="528799783"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{5, 342}, {189, 17}}</string>
-																<reference key="NSSuperview" ref="528799783"/>
-																<reference key="NSNextKeyView" ref="819029281"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSTextFieldCell" key="NSCell" id="197314660">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">71303168</int>
-																	<string key="NSContents">Auto accept file offers:</string>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="117258399"/>
-																	<reference key="NSBackgroundColor" ref="1007130360"/>
-																	<reference key="NSTextColor" ref="725989266"/>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSPopUpButton" id="819029281">
-																<reference key="NSNextResponder" ref="528799783"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{196, 340}, {128, 22}}</string>
-																<reference key="NSSuperview" ref="528799783"/>
-																<reference key="NSNextKeyView" ref="298337413"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSPopUpButtonCell" key="NSCell" id="159123237">
-																	<int key="NSCellFlags">-2076180416</int>
-																	<int key="NSCellFlags2">132096</int>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="819029281"/>
-																	<int key="NSButtonFlags">-2038284288</int>
-																	<int key="NSButtonFlags2">1</int>
-																	<reference key="NSAlternateImage" ref="26"/>
-																	<string key="NSAlternateContents"/>
-																	<object class="NSMutableString" key="NSKeyEquivalent">
-																		<characters key="NS.bytes"/>
-																	</object>
-																	<int key="NSPeriodicDelay">400</int>
-																	<int key="NSPeriodicInterval">75</int>
-																	<object class="NSMenuItem" key="NSMenuItem" id="732647984">
-																		<reference key="NSMenu" ref="254801121"/>
-																		<string key="NSTitle">Ask me</string>
-																		<string key="NSKeyEquiv"/>
-																		<int key="NSKeyEquivModMask">1048576</int>
-																		<int key="NSMnemonicLoc">2147483647</int>
-																		<int key="NSState">1</int>
-																		<reference key="NSOnImage" ref="123016255"/>
-																		<reference key="NSMixedImage" ref="138212614"/>
-																		<string key="NSAction">_popUpItemAction:</string>
-																		<reference key="NSTarget" ref="159123237"/>
-																	</object>
-																	<bool key="NSMenuItemRespectAlignment">YES</bool>
-																	<object class="NSMenu" key="NSMenu" id="254801121">
-																		<string key="NSTitle"/>
-																		<array class="NSMutableArray" key="NSMenuItems">
-																			<object class="NSMenuItem" id="404305924">
-																				<reference key="NSMenu" ref="254801121"/>
-																				<string key="NSTitle">No</string>
-																				<string key="NSKeyEquiv"/>
-																				<int key="NSKeyEquivModMask">1048576</int>
-																				<int key="NSMnemonicLoc">2147483647</int>
-																				<reference key="NSOnImage" ref="123016255"/>
-																				<reference key="NSMixedImage" ref="138212614"/>
-																				<string key="NSAction">_popUpItemAction:</string>
-																				<reference key="NSTarget" ref="159123237"/>
-																			</object>
-																			<object class="NSMenuItem" id="912128190">
-																				<reference key="NSMenu" ref="254801121"/>
-																				<string key="NSTitle">Yes</string>
-																				<string key="NSKeyEquiv"/>
-																				<int key="NSKeyEquivModMask">1048576</int>
-																				<int key="NSMnemonicLoc">2147483647</int>
-																				<reference key="NSOnImage" ref="123016255"/>
-																				<reference key="NSMixedImage" ref="138212614"/>
-																				<string key="NSAction">_popUpItemAction:</string>
-																				<reference key="NSTarget" ref="159123237"/>
-																			</object>
-																			<reference ref="732647984"/>
-																		</array>
-																	</object>
-																	<int key="NSSelectedIndex">2</int>
-																	<int key="NSPreferredEdge">3</int>
-																	<bool key="NSUsesItemFromMenu">YES</bool>
-																	<bool key="NSAltersState">YES</bool>
-																	<int key="NSArrowPosition">1</int>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSTextField" id="243082559">
-																<reference key="NSNextResponder" ref="528799783"/>
-																<int key="NSvFlags">266</int>
-																<string key="NSFrame">{{199, 317}, {230, 19}}</string>
-																<reference key="NSSuperview" ref="528799783"/>
-																<reference key="NSNextKeyView" ref="713833474"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSTextFieldCell" key="NSCell" id="349793878">
-																	<int key="NSCellFlags">-1804599231</int>
-																	<int key="NSCellFlags2">4195328</int>
-																	<string key="NSContents"/>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="243082559"/>
-																	<bool key="NSDrawsBackground">YES</bool>
-																	<reference key="NSBackgroundColor" ref="265355499"/>
-																	<reference key="NSTextColor" ref="328927124"/>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSTextField" id="409395540">
-																<reference key="NSNextResponder" ref="528799783"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{-3, 317}, {197, 19}}</string>
-																<reference key="NSSuperview" ref="528799783"/>
-																<reference key="NSNextKeyView" ref="243082559"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSTextFieldCell" key="NSCell" id="1006168066">
-																	<int key="NSCellFlags">67108864</int>
-																	<int key="NSCellFlags2">71303168</int>
-																	<string key="NSContents">Move completed files to:</string>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="409395540"/>
-																	<reference key="NSBackgroundColor" ref="1007130360"/>
-																	<reference key="NSTextColor" ref="725989266"/>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSTextField" id="296311144">
-																<reference key="NSNextResponder" ref="528799783"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{17, 369}, {323, 17}}</string>
-																<reference key="NSSuperview" ref="528799783"/>
-																<reference key="NSNextKeyView" ref="117258399"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSTextFieldCell" key="NSCell" id="653437884">
-																	<int key="NSCellFlags">68157504</int>
-																	<int key="NSCellFlags2">272630784</int>
-																	<string key="NSContents">Files and Directories</string>
-																	<reference key="NSSupport" ref="60143749"/>
-																	<reference key="NSControlView" ref="296311144"/>
-																	<reference key="NSBackgroundColor" ref="1007130360"/>
-																	<reference key="NSTextColor" ref="725989266"/>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSTextField" id="536293017">
-																<reference key="NSNextResponder" ref="528799783"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{17, 269}, {352, 17}}</string>
-																<reference key="NSSuperview" ref="528799783"/>
-																<reference key="NSNextKeyView" ref="455996658"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSTextFieldCell" key="NSCell" id="107688609">
-																	<int key="NSCellFlags">68157504</int>
-																	<int key="NSCellFlags2">272630784</int>
-																	<string key="NSContents">Network Settings</string>
-																	<reference key="NSSupport" ref="60143749"/>
-																	<reference key="NSControlView" ref="536293017"/>
-																	<reference key="NSBackgroundColor" ref="1007130360"/>
-																	<reference key="NSTextColor" ref="725989266"/>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-															<object class="NSTextField" id="724103728">
-																<reference key="NSNextResponder" ref="528799783"/>
-																<int key="NSvFlags">268</int>
-																<string key="NSFrame">{{243, 169}, {209, 11}}</string>
-																<reference key="NSSuperview" ref="528799783"/>
-																<reference key="NSNextKeyView" ref="1053574686"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSTextFieldCell" key="NSCell" id="1061114156">
-																	<int key="NSCellFlags">68157504</int>
-																	<int key="NSCellFlags2">272892928</int>
-																	<string key="NSContents">!Leave ports at zero for full range.</string>
-																	<reference key="NSSupport" ref="22"/>
-																	<reference key="NSControlView" ref="724103728"/>
-																	<reference key="NSBackgroundColor" ref="1007130360"/>
-																	<reference key="NSTextColor" ref="725989266"/>
-																</object>
-																<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															</object>
-														</array>
-														<string key="NSFrameSize">{449, 406}</string>
-														<reference key="NSNextKeyView" ref="296311144"/>
-													</object>
-													<reference key="NSColor" ref="1007130360"/>
-													<reference key="NSTabView" ref="1053574686"/>
-												</object>
-											</array>
-											<reference key="NSSelectedTabViewItem" ref="815118087"/>
-											<reference key="NSFont" ref="26"/>
-											<int key="NSTvFlags">134217734</int>
-											<bool key="NSAllowTruncatedLabels">YES</bool>
-											<array class="NSMutableArray" key="NSSubviews">
-												<reference ref="715816214"/>
-											</array>
-										</object>
-									</array>
-									<string key="NSFrame">{{2, 2}, {454, 408}}</string>
-									<reference key="NSSuperview" ref="543522030"/>
-									<reference key="NSWindow"/>
-									<reference key="NSNextKeyView" ref="1053574686"/>
-								</object>
-							</array>
-							<string key="NSFrame">{{162, 56}, {458, 428}}</string>
-							<reference key="NSSuperview" ref="812753686"/>
-							<reference key="NSWindow"/>
-							<reference key="NSNextKeyView" ref="27621534"/>
-							<string key="NSOffsets">{0, 0}</string>
-							<object class="NSTextFieldCell" key="NSTitleCell">
-								<int key="NSCellFlags">67108864</int>
-								<int key="NSCellFlags2">0</int>
-								<string key="NSContents">Text box</string>
-								<reference key="NSSupport" ref="218849127"/>
-								<reference key="NSBackgroundColor" ref="265355499"/>
-								<object class="NSColor" key="NSTextColor">
-									<int key="NSColorSpace">3</int>
-									<bytes key="NSWhite">MCAwLjgwMDAwMDAxMTkAA</bytes>
-								</object>
-							</object>
-							<reference key="NSContentView" ref="27621534"/>
-							<int key="NSBorderType">3</int>
-							<int key="NSBoxType">0</int>
-							<int key="NSTitlePosition">2</int>
-							<bool key="NSTransparent">NO</bool>
-						</object>
-						<object class="NSButton" id="665353132">
-							<reference key="NSNextResponder" ref="812753686"/>
-							<int key="NSvFlags">-2147483356</int>
-							<string key="NSFrame">{{14, 12}, {150, 32}}</string>
-							<reference key="NSSuperview" ref="812753686"/>
-							<reference key="NSWindow"/>
-							<reference key="NSNextKeyView" ref="26097905"/>
-							<bool key="NSEnabled">YES</bool>
-							<object class="NSButtonCell" key="NSCell" id="1036003946">
-								<int key="NSCellFlags">67108864</int>
-								<int key="NSCellFlags2">134217728</int>
-								<string key="NSContents">Show Prefs Files</string>
-								<reference key="NSSupport" ref="218849127"/>
-								<reference key="NSControlView" ref="665353132"/>
-								<int key="NSButtonFlags">-2038284288</int>
-								<int key="NSButtonFlags2">1</int>
-								<reference key="NSAlternateImage" ref="218849127"/>
-								<string key="NSAlternateContents"/>
-								<object class="NSMutableString" key="NSKeyEquivalent">
-									<characters key="NS.bytes"/>
-								</object>
-								<int key="NSPeriodicDelay">200</int>
-								<int key="NSPeriodicInterval">25</int>
-							</object>
-							<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-						</object>
-					</array>
-					<string key="NSFrameSize">{640, 497}</string>
-					<reference key="NSSuperview"/>
-					<reference key="NSWindow"/>
-					<reference key="NSNextKeyView" ref="977242452"/>
-				</object>
-				<string key="NSScreenRect">{{0, 0}, {1920, 1058}}</string>
-				<string key="NSMinSize">{640, 519}</string>
-				<string key="NSMaxSize">{640, 519}</string>
-				<bool key="NSWindowIsRestorable">YES</bool>
-			</object>
-		</array>
-		<object class="IBObjectContainer" key="IBDocument.Objects">
-			<array class="NSMutableArray" key="connectionRecords">
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">window</string>
-						<reference key="source" ref="11157371"/>
-						<reference key="destination" ref="120409092"/>
-					</object>
-					<int key="connectionID">905</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">dataSource</string>
-						<reference key="source" ref="532939042"/>
-						<reference key="destination" ref="120409092"/>
-					</object>
-					<int key="connectionID">706</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">delegate</string>
-						<reference key="source" ref="532939042"/>
-						<reference key="destination" ref="120409092"/>
-					</object>
-					<int key="connectionID">788</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">textBoxFontTextField</string>
-						<reference key="source" ref="120409092"/>
-						<reference key="destination" ref="117700411"/>
-					</object>
-					<int key="connectionID">664</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">maxLinesTextField</string>
-						<reference key="source" ref="120409092"/>
-						<reference key="destination" ref="69632604"/>
-					</object>
-					<int key="connectionID">665</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">coloredNicksCheckBox</string>
-						<reference key="source" ref="120409092"/>
-						<reference key="destination" ref="492037363"/>
-					</object>
-					<int key="connectionID">666</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">showSeparatorCheckBox</string>
-						<reference key="source" ref="120409092"/>
-						<reference key="destination" ref="452140972"/>
-					</object>
-					<int key="connectionID">668</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">stripMircColorCheckBox</string>
-						<reference key="source" ref="120409092"/>
-						<reference key="destination" ref="180817061"/>
-					</object>
-					<int key="connectionID">669</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">transparentCheckBox</string>
-						<reference key="source" ref="120409092"/>
-						<reference key="destination" ref="8070843"/>
-					</object>
-					<int key="connectionID">671</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">transparentSlider</string>
-						<reference key="source" ref="120409092"/>
-						<reference key="destination" ref="823087564"/>
-					</object>
-					<int key="connectionID">672</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">timeStampCheckBox</string>
-						<reference key="source" ref="120409092"/>
-						<reference key="destination" ref="40697488"/>
-					</object>
-					<int key="connectionID">673</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">timeStampFormatTextField</string>
-						<reference key="source" ref="120409092"/>
-						<reference key="destination" ref="15380591"/>
-					</object>
-					<int key="connectionID">674</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">inputBoxUseTextBoxFontCheckBox</string>
-						<reference key="source" ref="120409092"/>
-						<reference key="destination" ref="625485372"/>
-					</object>
-					<int key="connectionID">678</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">spellCheckingCheckBox</string>
-						<reference key="source" ref="120409092"/>
-						<reference key="destination" ref="186360774"/>
-					</object>
-					<int key="connectionID">679</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">interpretPercentAsciiCheckBox</string>
-						<reference key="source" ref="120409092"/>
-						<reference key="destination" ref="1049155740"/>
-					</object>
-					<int key="connectionID">680</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">interpretPercentColorCheckBox</string>
-						<reference key="source" ref="120409092"/>
-						<reference key="destination" ref="1064535331"/>
-					</object>
-					<int key="connectionID">681</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">suffixCompletionCheckBox</string>
-						<reference key="source" ref="120409092"/>
-						<reference key="destination" ref="890839872"/>
-					</object>
-					<int key="connectionID">682</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">suffixCompletionTextField</string>
-						<reference key="source" ref="120409092"/>
-						<reference key="destination" ref="1031487992"/>
-					</object>
-					<int key="connectionID">683</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">tabCompletionCheckBox</string>
-						<reference key="source" ref="120409092"/>
-						<reference key="destination" ref="534115331"/>
-					</object>
-					<int key="connectionID">684</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">nickCompletionSortPopUp</string>
-						<reference key="source" ref="120409092"/>
-						<reference key="destination" ref="448930768"/>
-					</object>
-					<int key="connectionID">685</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">scrollingCompletionCheckBox</string>
-						<reference key="source" ref="120409092"/>
-						<reference key="destination" ref="515286899"/>
-					</object>
-					<int key="connectionID">686</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">showHostnameCheckBox</string>
-						<reference key="source" ref="120409092"/>
-						<reference key="destination" ref="443451250"/>
-					</object>
-					<int key="connectionID">687</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">hideUserlistCheckBox</string>
-						<reference key="source" ref="120409092"/>
-						<reference key="destination" ref="702422028"/>
-					</object>
-					<int key="connectionID">688</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">userlistSortPopUp</string>
-						<reference key="source" ref="120409092"/>
-						<reference key="destination" ref="544344533"/>
-					</object>
-					<int key="connectionID">689</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">showUserlistButtonsCheckBox</string>
-						<reference key="source" ref="120409092"/>
-						<reference key="destination" ref="843004622"/>
-					</object>
-					<int key="connectionID">690</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">doubleClickCommandTextField</string>
-						<reference key="source" ref="120409092"/>
-						<reference key="destination" ref="67211373"/>
-					</object>
-					<int key="connectionID">691</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">newTabsToFrontCheckBox</string>
-						<reference key="source" ref="120409092"/>
-						<reference key="destination" ref="787268415"/>
-					</object>
-					<int key="connectionID">692</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">useServerTabCheckBox</string>
-						<reference key="source" ref="120409092"/>
-						<reference key="destination" ref="647588713"/>
-					</object>
-					<int key="connectionID">693</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">useNoticesTabCheckBox</string>
-						<reference key="source" ref="120409092"/>
-						<reference key="destination" ref="446924427"/>
-					</object>
-					<int key="connectionID">694</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">hideTabCloseButtonsCheckBox</string>
-						<reference key="source" ref="120409092"/>
-						<reference key="destination" ref="118189423"/>
-					</object>
-					<int key="connectionID">695</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">tabPositionPopUp</string>
-						<reference key="source" ref="120409092"/>
-						<reference key="destination" ref="100869595"/>
-					</object>
-					<int key="connectionID">697</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">tabView</string>
-						<reference key="source" ref="120409092"/>
-						<reference key="destination" ref="1053574686"/>
-					</object>
-					<int key="connectionID">699</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">openChannelsInPopUp</string>
-						<reference key="source" ref="120409092"/>
-						<reference key="destination" ref="859866171"/>
-					</object>
-					<int key="connectionID">700</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">openDialogsInPopUp</string>
-						<reference key="source" ref="120409092"/>
-						<reference key="destination" ref="601992312"/>
-					</object>
-					<int key="connectionID">701</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">openUtilitiesInPopUp</string>
-						<reference key="source" ref="120409092"/>
-						<reference key="destination" ref="375046315"/>
-					</object>
-					<int key="connectionID">702</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">showChannelModeButtonsCheckBox</string>
-						<reference key="source" ref="120409092"/>
-						<reference key="destination" ref="235267684"/>
-					</object>
-					<int key="connectionID">703</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">defaultCharsetTextField</string>
-						<reference key="source" ref="120409092"/>
-						<reference key="destination" ref="179272392"/>
-					</object>
-					<int key="connectionID">704</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">categoryOutlineView</string>
-						<reference key="source" ref="120409092"/>
-						<reference key="destination" ref="532939042"/>
-					</object>
-					<int key="connectionID">705</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">extraHighlightWordsTextField</string>
-						<reference key="source" ref="120409092"/>
-						<reference key="destination" ref="746284896"/>
-					</object>
-					<int key="connectionID">715</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">beepOnChannelCheckBox</string>
-						<reference key="source" ref="120409092"/>
-						<reference key="destination" ref="666364138"/>
-					</object>
-					<int key="connectionID">722</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">beepOnPrivateCheckBox</string>
-						<reference key="source" ref="120409092"/>
-						<reference key="destination" ref="366330173"/>
-					</object>
-					<int key="connectionID">723</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">awayMessageTextField</string>
-						<reference key="source" ref="120409092"/>
-						<reference key="destination" ref="261722805"/>
-					</object>
-					<int key="connectionID">724</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">partMessageTextField</string>
-						<reference key="source" ref="120409092"/>
-						<reference key="destination" ref="458271500"/>
-					</object>
-					<int key="connectionID">725</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">sleepMessageTextField</string>
-						<reference key="source" ref="120409092"/>
-						<reference key="destination" ref="588693457"/>
-					</object>
-					<int key="connectionID">726</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">quitMessageTextField</string>
-						<reference key="source" ref="120409092"/>
-						<reference key="destination" ref="223828555"/>
-					</object>
-					<int key="connectionID">727</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">autoAwayCheckBox</string>
-						<reference key="source" ref="120409092"/>
-						<reference key="destination" ref="445128323"/>
-					</object>
-					<int key="connectionID">728</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">autoAwayMinutesTextField</string>
-						<reference key="source" ref="120409092"/>
-						<reference key="destination" ref="672147861"/>
-					</object>
-					<int key="connectionID">729</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">showAwayMessageCheckBox</string>
-						<reference key="source" ref="120409092"/>
-						<reference key="destination" ref="262685444"/>
-					</object>
-					<int key="connectionID">730</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">showAwayOnceCheckBox</string>
-						<reference key="source" ref="120409092"/>
-						<reference key="destination" ref="1055673271"/>
-					</object>
-					<int key="connectionID">731</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">autoUnmarkAwayCheckBox</string>
-						<reference key="source" ref="120409092"/>
-						<reference key="destination" ref="123971144"/>
-					</object>
-					<int key="connectionID">732</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">autoDialogCheckBox</string>
-						<reference key="source" ref="120409092"/>
-						<reference key="destination" ref="309106554"/>
-					</object>
-					<int key="connectionID">733</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">enableLoggingCheckBox</string>
-						<reference key="source" ref="120409092"/>
-						<reference key="destination" ref="325970917"/>
-					</object>
-					<int key="connectionID">740</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">logFilenameMaskTextField</string>
-						<reference key="source" ref="120409092"/>
-						<reference key="destination" ref="140016662"/>
-					</object>
-					<int key="connectionID">741</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">timestampsInLogsCheckBox</string>
-						<reference key="source" ref="120409092"/>
-						<reference key="destination" ref="367266019"/>
-					</object>
-					<int key="connectionID">742</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">timestampInLogsFormatTextField</string>
-						<reference key="source" ref="120409092"/>
-						<reference key="destination" ref="311410408"/>
-					</object>
-					<int key="connectionID">743</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">soundsTableView</string>
-						<reference key="source" ref="120409092"/>
-						<reference key="destination" ref="932713766"/>
-					</object>
-					<int key="connectionID">747</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">bindAddressTextField</string>
-						<reference key="source" ref="120409092"/>
-						<reference key="destination" ref="14999216"/>
-					</object>
-					<int key="connectionID">750</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">proxyHostTextField</string>
-						<reference key="source" ref="120409092"/>
-						<reference key="destination" ref="687146077"/>
-					</object>
-					<int key="connectionID">751</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">proxyPortTextField</string>
-						<reference key="source" ref="120409092"/>
-						<reference key="destination" ref="975592998"/>
-					</object>
-					<int key="connectionID">752</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">proxyTypePopUp</string>
-						<reference key="source" ref="120409092"/>
-						<reference key="destination" ref="291755447"/>
-					</object>
-					<int key="connectionID">753</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">partOnSleepCheckBox</string>
-						<reference key="source" ref="120409092"/>
-						<reference key="destination" ref="531383733"/>
-					</object>
-					<int key="connectionID">754</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">autoReconnectCheckBox</string>
-						<reference key="source" ref="120409092"/>
-						<reference key="destination" ref="422271573"/>
-					</object>
-					<int key="connectionID">755</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">autoReconnectDelayTextField</string>
-						<reference key="source" ref="120409092"/>
-						<reference key="destination" ref="410813163"/>
-					</object>
-					<int key="connectionID">756</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">identdCheckBox</string>
-						<reference key="source" ref="120409092"/>
-						<reference key="destination" ref="1062025260"/>
-					</object>
-					<int key="connectionID">757</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">neverGiveUpReconnectionCheckBox</string>
-						<reference key="source" ref="120409092"/>
-						<reference key="destination" ref="720402574"/>
-					</object>
-					<int key="connectionID">758</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">downloadsDirectoryTextField</string>
-						<reference key="source" ref="120409092"/>
-						<reference key="destination" ref="879421054"/>
-					</object>
-					<int key="connectionID">760</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">downloadSpaceToUnderscoreCheckBox</string>
-						<reference key="source" ref="120409092"/>
-						<reference key="destination" ref="324798199"/>
-					</object>
-					<int key="connectionID">761</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">downloadWithNickCheckBox</string>
-						<reference key="source" ref="120409092"/>
-						<reference key="destination" ref="713833474"/>
-					</object>
-					<int key="connectionID">762</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">completedDownloadsDirectoryTextField</string>
-						<reference key="source" ref="120409092"/>
-						<reference key="destination" ref="243082559"/>
-					</object>
-					<int key="connectionID">763</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">ipFromServerCheckBox</string>
-						<reference key="source" ref="120409092"/>
-						<reference key="destination" ref="455996658"/>
-					</object>
-					<int key="connectionID">768</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">dccAddressTextField</string>
-						<reference key="source" ref="120409092"/>
-						<reference key="destination" ref="391437494"/>
-					</object>
-					<int key="connectionID">769</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">dccFirstSendPortTextField</string>
-						<reference key="source" ref="120409092"/>
-						<reference key="destination" ref="617259440"/>
-					</object>
-					<int key="connectionID">770</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">dccLastSendPortTextField</string>
-						<reference key="source" ref="120409092"/>
-						<reference key="destination" ref="86962169"/>
-					</object>
-					<int key="connectionID">771</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">autoAcceptDccPopUp</string>
-						<reference key="source" ref="120409092"/>
-						<reference key="destination" ref="819029281"/>
-					</object>
-					<int key="connectionID">772</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">contentBox</string>
-						<reference key="source" ref="120409092"/>
-						<reference key="destination" ref="543522030"/>
-					</object>
-					<int key="connectionID">773</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">indentNicksCheckBox</string>
-						<reference key="source" ref="120409092"/>
-						<reference key="destination" ref="206913966"/>
-					</object>
-					<int key="connectionID">779</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBActionConnection" key="connection">
-						<string key="label">applyFont:</string>
-						<reference key="source" ref="120409092"/>
-						<reference key="destination" ref="1007387692"/>
-					</object>
-					<int key="connectionID">780</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBActionConnection" key="connection">
-						<string key="label">applyPreferences:</string>
-						<reference key="source" ref="120409092"/>
-						<reference key="destination" ref="26097905"/>
-					</object>
-					<int key="connectionID">781</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBActionConnection" key="connection">
-						<string key="label">showRawPreferences:</string>
-						<reference key="source" ref="120409092"/>
-						<reference key="destination" ref="665353132"/>
-					</object>
-					<int key="connectionID">782</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBActionConnection" key="connection">
-						<string key="label">performOK:</string>
-						<reference key="source" ref="120409092"/>
-						<reference key="destination" ref="247430523"/>
-					</object>
-					<int key="connectionID">783</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBActionConnection" key="connection">
-						<string key="label">performCancel:</string>
-						<reference key="source" ref="120409092"/>
-						<reference key="destination" ref="662298341"/>
-					</object>
-					<int key="connectionID">784</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBActionConnection" key="connection">
-						<string key="label">applyTranparency:</string>
-						<reference key="source" ref="120409092"/>
-						<reference key="destination" ref="823087564"/>
-					</object>
-					<int key="connectionID">785</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBActionConnection" key="connection">
-						<string key="label">applyTranparency:</string>
-						<reference key="source" ref="120409092"/>
-						<reference key="destination" ref="8070843"/>
-					</object>
-					<int key="connectionID">786</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">colorsTabViewItem</string>
-						<reference key="source" ref="120409092"/>
-						<reference key="destination" ref="625907395"/>
-					</object>
-					<int key="connectionID">793</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">awayMaxSizeTextField</string>
-						<reference key="source" ref="120409092"/>
-						<reference key="destination" ref="542998689"/>
-					</object>
-					<int key="connectionID">804</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">awayTrackCheckBox</string>
-						<reference key="source" ref="120409092"/>
-						<reference key="destination" ref="367627207"/>
-					</object>
-					<int key="connectionID">805</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">shortenTabLabelLengthTextField</string>
-						<reference key="source" ref="120409092"/>
-						<reference key="destination" ref="449540546"/>
-					</object>
-					<int key="connectionID">810</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">noHighlightWordsTextField</string>
-						<reference key="source" ref="120409092"/>
-						<reference key="destination" ref="637075528"/>
-					</object>
-					<int key="connectionID">819</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">nickHighlightWordsTextField</string>
-						<reference key="source" ref="120409092"/>
-						<reference key="destination" ref="1028551236"/>
-					</object>
-					<int key="connectionID">820</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">beepOnHighlightedCheckBox</string>
-						<reference key="source" ref="120409092"/>
-						<reference key="destination" ref="998640248"/>
-					</object>
-					<int key="connectionID">823</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">displayPreviousScrollbackCheckBox</string>
-						<reference key="source" ref="120409092"/>
-						<reference key="destination" ref="506678724"/>
-					</object>
-					<int key="connectionID">832</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">proxyUsePopup</string>
-						<reference key="source" ref="120409092"/>
-						<reference key="destination" ref="199654805"/>
-					</object>
-					<int key="connectionID">843</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">proxyAuthenicationCheckBox</string>
-						<reference key="source" ref="120409092"/>
-						<reference key="destination" ref="887471351"/>
-					</object>
-					<int key="connectionID">856</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">proxyPasswordTextField</string>
-						<reference key="source" ref="120409092"/>
-						<reference key="destination" ref="317149642"/>
-					</object>
-					<int key="connectionID">857</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">proxyUsernameTextField</string>
-						<reference key="source" ref="120409092"/>
-						<reference key="destination" ref="823414242"/>
-					</object>
-					<int key="connectionID">858</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">switcherTypePopUp</string>
-						<reference key="source" ref="120409092"/>
-						<reference key="destination" ref="317580382"/>
-					</object>
-					<int key="connectionID">882</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">backgroundImageTextField</string>
-						<reference key="source" ref="120409092"/>
-						<reference key="destination" ref="195567578"/>
-					</object>
-					<int key="connectionID">890</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBActionConnection" key="connection">
-						<string key="label">applyBackgroundImage:</string>
-						<reference key="source" ref="120409092"/>
-						<reference key="destination" ref="619505271"/>
-					</object>
-					<int key="connectionID">891</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBActionConnection" key="connection">
-						<string key="label">removeBackgroundImage:</string>
-						<reference key="source" ref="120409092"/>
-						<reference key="destination" ref="311130897"/>
-					</object>
-					<int key="connectionID">897</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">smallerTextTabCheckBox</string>
-						<reference key="source" ref="120409092"/>
-						<reference key="destination" ref="237037613"/>
-					</object>
-					<int key="connectionID">900</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">userlistUseTextBoxFontCheckBox</string>
-						<reference key="source" ref="120409092"/>
-						<reference key="destination" ref="846995571"/>
-					</object>
-					<int key="connectionID">912</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBActionConnection" key="connection">
-						<string key="label">loadColorFromDefault:</string>
-						<reference key="source" ref="120409092"/>
-						<reference key="destination" ref="479388100"/>
-					</object>
-					<int key="connectionID">917</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBActionConnection" key="connection">
-						<string key="label">loadColorFromFile:</string>
-						<reference key="source" ref="120409092"/>
-						<reference key="destination" ref="501949360"/>
-					</object>
-					<int key="connectionID">918</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">autoRejoinCheckBox</string>
-						<reference key="source" ref="120409092"/>
-						<reference key="destination" ref="386977525"/>
-					</object>
-					<int key="connectionID">961</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">hideJoinPartCheckBox</string>
-						<reference key="source" ref="120409092"/>
-						<reference key="destination" ref="635477378"/>
-					</object>
-					<int key="connectionID">962</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">rawModesCheckBox</string>
-						<reference key="source" ref="120409092"/>
-						<reference key="destination" ref="645188295"/>
-					</object>
-					<int key="connectionID">963</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">whoisOnNotifyCheckBox</string>
-						<reference key="source" ref="120409092"/>
-						<reference key="destination" ref="400997636"/>
-					</object>
-					<int key="connectionID">964</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">autoOpenDccSendCheckBox</string>
-						<reference key="source" ref="120409092"/>
-						<reference key="destination" ref="587008753"/>
-					</object>
-					<int key="connectionID">776</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">autoOpenDccChatCheckBox</string>
-						<reference key="source" ref="120409092"/>
-						<reference key="destination" ref="364692266"/>
-					</object>
-					<int key="connectionID">774</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">autoOpenDccReceiveCheckBox</string>
-						<reference key="source" ref="120409092"/>
-						<reference key="destination" ref="602004972"/>
-					</object>
-					<int key="connectionID">775</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">autoAcceptDccChatPopUp</string>
-						<reference key="source" ref="120409092"/>
-						<reference key="destination" ref="546931793"/>
-					</object>
-					<int key="connectionID">777</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">scrollbackStripColorCheckBox</string>
-						<reference key="source" ref="120409092"/>
-						<reference key="destination" ref="232859697"/>
-					</object>
-					<int key="connectionID">967</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">urlLinkCommandTextField</string>
-						<reference key="source" ref="120409092"/>
-						<reference key="destination" ref="50263017"/>
-					</object>
-					<int key="connectionID">675</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">nickLinkCommandTextField</string>
-						<reference key="source" ref="120409092"/>
-						<reference key="destination" ref="627093559"/>
-					</object>
-					<int key="connectionID">677</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">channelLinkCommandTextField</string>
-						<reference key="source" ref="120409092"/>
-						<reference key="destination" ref="388795386"/>
-					</object>
-					<int key="connectionID">676</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">lineHeightTextField</string>
-						<reference key="source" ref="120409092"/>
-						<reference key="destination" ref="16204397"/>
-					</object>
-					<int key="connectionID">974</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">bounceCountinuouslyCheckBox</string>
-						<reference key="source" ref="120409092"/>
-						<reference key="destination" ref="813833386"/>
-					</object>
-					<int key="connectionID">977</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">grammerCheckingCheckBox</string>
-						<reference key="source" ref="120409092"/>
-						<reference key="destination" ref="257956724"/>
-					</object>
-					<int key="connectionID">982</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">autocorrectionCheckBox</string>
-						<reference key="source" ref="120409092"/>
-						<reference key="destination" ref="667026855"/>
-					</object>
-					<int key="connectionID">983</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">dataSource</string>
-						<reference key="source" ref="932713766"/>
-						<reference key="destination" ref="120409092"/>
-					</object>
-					<int key="connectionID">745</int>
-				</object>
-			</array>
-			<object class="IBMutableOrderedSet" key="objectRecords">
-				<array key="orderedObjects">
-					<object class="IBObjectRecord">
-						<int key="objectID">0</int>
-						<array key="object" id="0"/>
-						<reference key="children" ref="156144608"/>
-						<nil key="parent"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">-2</int>
-						<reference key="object" ref="11157371"/>
-						<reference key="parent" ref="0"/>
-						<string key="objectName">File's Owner</string>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">-1</int>
-						<reference key="object" ref="402593865"/>
-						<reference key="parent" ref="0"/>
-						<string key="objectName">First Responder</string>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">111</int>
-						<reference key="object" ref="120409092"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="812753686"/>
-						</array>
-						<reference key="parent" ref="0"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">81</int>
-						<reference key="object" ref="812753686"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="543522030"/>
-							<reference ref="977242452"/>
-							<reference ref="247430523"/>
-							<reference ref="662298341"/>
-							<reference ref="26097905"/>
-							<reference ref="665353132"/>
-						</array>
-						<reference key="parent" ref="120409092"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">48</int>
-						<reference key="object" ref="543522030"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="1053574686"/>
-						</array>
-						<reference key="parent" ref="812753686"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">55</int>
-						<reference key="object" ref="26097905"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="737667532"/>
-						</array>
-						<reference key="parent" ref="812753686"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">56</int>
-						<reference key="object" ref="977242452"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="532939042"/>
-							<reference ref="878483055"/>
-							<reference ref="424564569"/>
-						</array>
-						<reference key="parent" ref="812753686"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">24</int>
-						<reference key="object" ref="532939042"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="833634636"/>
-						</array>
-						<reference key="parent" ref="977242452"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">41</int>
-						<reference key="object" ref="833634636"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="208271096"/>
-						</array>
-						<reference key="parent" ref="532939042"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">80</int>
-						<reference key="object" ref="665353132"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="1036003946"/>
-						</array>
-						<reference key="parent" ref="812753686"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">107</int>
-						<reference key="object" ref="247430523"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="375248671"/>
-						</array>
-						<reference key="parent" ref="812753686"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">198</int>
-						<reference key="object" ref="662298341"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="295232266"/>
-						</array>
-						<reference key="parent" ref="812753686"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">576</int>
-						<reference key="object" ref="737667532"/>
-						<reference key="parent" ref="26097905"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">577</int>
-						<reference key="object" ref="1036003946"/>
-						<reference key="parent" ref="665353132"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">578</int>
-						<reference key="object" ref="375248671"/>
-						<reference key="parent" ref="247430523"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">579</int>
-						<reference key="object" ref="295232266"/>
-						<reference key="parent" ref="662298341"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">585</int>
-						<reference key="object" ref="208271096"/>
-						<reference key="parent" ref="833634636"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">589</int>
-						<reference key="object" ref="878483055"/>
-						<reference key="parent" ref="977242452"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">590</int>
-						<reference key="object" ref="424564569"/>
-						<reference key="parent" ref="977242452"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">-3</int>
-						<reference key="object" ref="676093597"/>
-						<reference key="parent" ref="0"/>
-						<string key="objectName">Application</string>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">65</int>
-						<reference key="object" ref="1053574686"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="700045870"/>
-							<reference ref="882238021"/>
-							<reference ref="1040782865"/>
-							<reference ref="82298705"/>
-							<reference ref="410501168"/>
-							<reference ref="815118087"/>
-							<reference ref="513972833"/>
-							<reference ref="40875324"/>
-							<reference ref="625907395"/>
-							<reference ref="1041246667"/>
-							<reference ref="633363925"/>
-							<reference ref="23773977"/>
-							<reference ref="1069702818"/>
-						</array>
-						<reference key="parent" ref="543522030"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">313</int>
-						<reference key="object" ref="700045870"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="208408466"/>
-						</array>
-						<reference key="parent" ref="1053574686"/>
-						<string key="objectName">Sound</string>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">218</int>
-						<reference key="object" ref="882238021"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="416415920"/>
-						</array>
-						<reference key="parent" ref="1053574686"/>
-						<string key="objectName">Input box</string>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">168</int>
-						<reference key="object" ref="1040782865"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="19718304"/>
-						</array>
-						<reference key="parent" ref="1053574686"/>
-						<string key="objectName">User list</string>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">135</int>
-						<reference key="object" ref="82298705"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="528799783"/>
-						</array>
-						<reference key="parent" ref="1053574686"/>
-						<string key="objectName">File transfers</string>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">126</int>
-						<reference key="object" ref="410501168"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="131199459"/>
-						</array>
-						<reference key="parent" ref="1053574686"/>
-						<string key="objectName">Network setup</string>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">87</int>
-						<reference key="object" ref="815118087"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="715816214"/>
-						</array>
-						<reference key="parent" ref="1053574686"/>
-						<string key="objectName">Text box</string>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">64</int>
-						<reference key="object" ref="513972833"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="57587199"/>
-						</array>
-						<reference key="parent" ref="1053574686"/>
-						<string key="objectName">Logging</string>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">50</int>
-						<reference key="object" ref="40875324"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="820917927"/>
-						</array>
-						<reference key="parent" ref="1053574686"/>
-						<string key="objectName">Channel switcher</string>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">38</int>
-						<reference key="object" ref="625907395"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="402415888"/>
-						</array>
-						<reference key="parent" ref="1053574686"/>
-						<string key="objectName">Colors</string>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">26</int>
-						<reference key="object" ref="1041246667"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="432098287"/>
-						</array>
-						<reference key="parent" ref="1053574686"/>
-						<string key="objectName">Other</string>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">19</int>
-						<reference key="object" ref="633363925"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="55856611"/>
-						</array>
-						<reference key="parent" ref="1053574686"/>
-						<string key="objectName">General</string>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">123</int>
-						<reference key="object" ref="55856611"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="223828555"/>
-							<reference ref="68392803"/>
-							<reference ref="427166787"/>
-							<reference ref="458271500"/>
-							<reference ref="108020218"/>
-							<reference ref="261722805"/>
-							<reference ref="107180245"/>
-							<reference ref="421761115"/>
-							<reference ref="588693457"/>
-							<reference ref="127529838"/>
-							<reference ref="262685444"/>
-							<reference ref="531383733"/>
-							<reference ref="445128323"/>
-							<reference ref="672147861"/>
-							<reference ref="871847337"/>
-							<reference ref="1055673271"/>
-							<reference ref="123971144"/>
-						</array>
-						<reference key="parent" ref="633363925"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">409</int>
-						<reference key="object" ref="871847337"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="743162796"/>
-						</array>
-						<reference key="parent" ref="55856611"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">408</int>
-						<reference key="object" ref="672147861"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="786534123"/>
-						</array>
-						<reference key="parent" ref="55856611"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">407</int>
-						<reference key="object" ref="445128323"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="888164047"/>
-						</array>
-						<reference key="parent" ref="55856611"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">377</int>
-						<reference key="object" ref="531383733"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="902285033"/>
-						</array>
-						<reference key="parent" ref="55856611"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">323</int>
-						<reference key="object" ref="588693457"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="117096224"/>
-						</array>
-						<reference key="parent" ref="55856611"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">322</int>
-						<reference key="object" ref="421761115"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="57504781"/>
-						</array>
-						<reference key="parent" ref="55856611"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">202</int>
-						<reference key="object" ref="108020218"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="237938749"/>
-						</array>
-						<reference key="parent" ref="55856611"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">165</int>
-						<reference key="object" ref="107180245"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="293992041"/>
-						</array>
-						<reference key="parent" ref="55856611"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">162</int>
-						<reference key="object" ref="1055673271"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="943369683"/>
-						</array>
-						<reference key="parent" ref="55856611"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">125</int>
-						<reference key="object" ref="261722805"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="272219725"/>
-						</array>
-						<reference key="parent" ref="55856611"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">114</int>
-						<reference key="object" ref="262685444"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="480489821"/>
-						</array>
-						<reference key="parent" ref="55856611"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">110</int>
-						<reference key="object" ref="458271500"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="469446840"/>
-						</array>
-						<reference key="parent" ref="55856611"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">95</int>
-						<reference key="object" ref="68392803"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="585272136"/>
-						</array>
-						<reference key="parent" ref="55856611"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">40</int>
-						<reference key="object" ref="223828555"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="584215286"/>
-						</array>
-						<reference key="parent" ref="55856611"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">17</int>
-						<reference key="object" ref="123971144"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="38837654"/>
-						</array>
-						<reference key="parent" ref="55856611"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">422</int>
-						<reference key="object" ref="38837654"/>
-						<reference key="parent" ref="123971144"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">423</int>
-						<reference key="object" ref="584215286"/>
-						<reference key="parent" ref="223828555"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">427</int>
-						<reference key="object" ref="585272136"/>
-						<reference key="parent" ref="68392803"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">428</int>
-						<reference key="object" ref="469446840"/>
-						<reference key="parent" ref="458271500"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">429</int>
-						<reference key="object" ref="480489821"/>
-						<reference key="parent" ref="262685444"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">432</int>
-						<reference key="object" ref="272219725"/>
-						<reference key="parent" ref="261722805"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">435</int>
-						<reference key="object" ref="943369683"/>
-						<reference key="parent" ref="1055673271"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">436</int>
-						<reference key="object" ref="293992041"/>
-						<reference key="parent" ref="107180245"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">439</int>
-						<reference key="object" ref="237938749"/>
-						<reference key="parent" ref="108020218"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">440</int>
-						<reference key="object" ref="57504781"/>
-						<reference key="parent" ref="421761115"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">441</int>
-						<reference key="object" ref="117096224"/>
-						<reference key="parent" ref="588693457"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">442</int>
-						<reference key="object" ref="902285033"/>
-						<reference key="parent" ref="531383733"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">443</int>
-						<reference key="object" ref="888164047"/>
-						<reference key="parent" ref="445128323"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">444</int>
-						<reference key="object" ref="786534123"/>
-						<reference key="parent" ref="672147861"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">445</int>
-						<reference key="object" ref="743162796"/>
-						<reference key="parent" ref="871847337"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">35</int>
-						<reference key="object" ref="432098287"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="293871888"/>
-							<reference ref="235267684"/>
-							<reference ref="616293540"/>
-							<reference ref="179272392"/>
-							<reference ref="533408090"/>
-							<reference ref="697368484"/>
-							<reference ref="50263017"/>
-							<reference ref="584056154"/>
-							<reference ref="627093559"/>
-							<reference ref="388795386"/>
-							<reference ref="1051657128"/>
-							<reference ref="883100964"/>
-						</array>
-						<reference key="parent" ref="1041246667"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">358</int>
-						<reference key="object" ref="293871888"/>
-						<array class="NSMutableArray" key="children"/>
-						<reference key="parent" ref="432098287"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">357</int>
-						<reference key="object" ref="179272392"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="552807489"/>
-						</array>
-						<reference key="parent" ref="432098287"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">356</int>
-						<reference key="object" ref="616293540"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="334746212"/>
-						</array>
-						<reference key="parent" ref="432098287"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">91</int>
-						<reference key="object" ref="235267684"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="546879026"/>
-						</array>
-						<reference key="parent" ref="432098287"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">446</int>
-						<reference key="object" ref="546879026"/>
-						<reference key="parent" ref="235267684"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">447</int>
-						<reference key="object" ref="334746212"/>
-						<reference key="parent" ref="616293540"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">448</int>
-						<reference key="object" ref="552807489"/>
-						<reference key="parent" ref="179272392"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">33</int>
-						<reference key="object" ref="402415888"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="233349765"/>
-							<reference ref="1038163933"/>
-							<reference ref="824992908"/>
-							<reference ref="511299136"/>
-							<reference ref="271561416"/>
-							<reference ref="727596136"/>
-							<reference ref="163181294"/>
-							<reference ref="772434347"/>
-							<reference ref="960025613"/>
-							<reference ref="1055210306"/>
-							<reference ref="532978015"/>
-							<reference ref="854857905"/>
-							<reference ref="161554151"/>
-							<reference ref="958081887"/>
-							<reference ref="504661049"/>
-							<reference ref="748452430"/>
-							<reference ref="118049744"/>
-							<reference ref="43449478"/>
-							<reference ref="155506199"/>
-							<reference ref="140668850"/>
-							<reference ref="103645729"/>
-							<reference ref="684434690"/>
-							<reference ref="310238798"/>
-							<reference ref="500715027"/>
-							<reference ref="68055949"/>
-							<reference ref="411107394"/>
-							<reference ref="425465266"/>
-							<reference ref="648433288"/>
-							<reference ref="650187603"/>
-							<reference ref="369930811"/>
-							<reference ref="222278178"/>
-							<reference ref="23368208"/>
-							<reference ref="83455403"/>
-							<reference ref="340464604"/>
-							<reference ref="765851134"/>
-							<reference ref="576768000"/>
-							<reference ref="44841208"/>
-							<reference ref="968109138"/>
-							<reference ref="686202698"/>
-							<reference ref="180153678"/>
-							<reference ref="1063522251"/>
-							<reference ref="409264205"/>
-							<reference ref="272186419"/>
-							<reference ref="479388100"/>
-							<reference ref="48224885"/>
-							<reference ref="957933488"/>
-							<reference ref="925310567"/>
-							<reference ref="193332999"/>
-							<reference ref="722652568"/>
-							<reference ref="687336195"/>
-							<reference ref="638265677"/>
-							<reference ref="795324312"/>
-							<reference ref="1031955050"/>
-							<reference ref="514898890"/>
-							<reference ref="513306894"/>
-							<reference ref="690043882"/>
-							<reference ref="44557163"/>
-							<reference ref="831000751"/>
-							<reference ref="840033143"/>
-							<reference ref="208667344"/>
-							<reference ref="489144235"/>
-							<reference ref="350511929"/>
-							<reference ref="233102631"/>
-							<reference ref="1026900652"/>
-							<reference ref="258665417"/>
-							<reference ref="782529362"/>
-							<reference ref="216298000"/>
-							<reference ref="350197855"/>
-							<reference ref="78293204"/>
-							<reference ref="282776959"/>
-							<reference ref="501949360"/>
-						</array>
-						<reference key="parent" ref="625907395"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">353</int>
-						<reference key="object" ref="968109138"/>
-						<reference key="parent" ref="402415888"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">352</int>
-						<reference key="object" ref="216298000"/>
-						<reference key="parent" ref="402415888"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">351</int>
-						<reference key="object" ref="233102631"/>
-						<reference key="parent" ref="402415888"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">350</int>
-						<reference key="object" ref="782529362"/>
-						<reference key="parent" ref="402415888"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">349</int>
-						<reference key="object" ref="44841208"/>
-						<reference key="parent" ref="402415888"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">348</int>
-						<reference key="object" ref="350197855"/>
-						<reference key="parent" ref="402415888"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">347</int>
-						<reference key="object" ref="840033143"/>
-						<reference key="parent" ref="402415888"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">346</int>
-						<reference key="object" ref="282776959"/>
-						<reference key="parent" ref="402415888"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">345</int>
-						<reference key="object" ref="208667344"/>
-						<reference key="parent" ref="402415888"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">344</int>
-						<reference key="object" ref="925310567"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="373482299"/>
-						</array>
-						<reference key="parent" ref="402415888"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">343</int>
-						<reference key="object" ref="489144235"/>
-						<reference key="parent" ref="402415888"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">342</int>
-						<reference key="object" ref="576768000"/>
-						<reference key="parent" ref="402415888"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">341</int>
-						<reference key="object" ref="78293204"/>
-						<reference key="parent" ref="402415888"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">340</int>
-						<reference key="object" ref="258665417"/>
-						<reference key="parent" ref="402415888"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">339</int>
-						<reference key="object" ref="1026900652"/>
-						<reference key="parent" ref="402415888"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">338</int>
-						<reference key="object" ref="350511929"/>
-						<reference key="parent" ref="402415888"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">337</int>
-						<reference key="object" ref="765851134"/>
-						<reference key="parent" ref="402415888"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">224</int>
-						<reference key="object" ref="163181294"/>
-						<reference key="parent" ref="402415888"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">221</int>
-						<reference key="object" ref="831000751"/>
-						<reference key="parent" ref="402415888"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">212</int>
-						<reference key="object" ref="957933488"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="558234484"/>
-						</array>
-						<reference key="parent" ref="402415888"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">199</int>
-						<reference key="object" ref="161554151"/>
-						<reference key="parent" ref="402415888"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">196</int>
-						<reference key="object" ref="748452430"/>
-						<reference key="parent" ref="402415888"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">193</int>
-						<reference key="object" ref="532978015"/>
-						<reference key="parent" ref="402415888"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">191</int>
-						<reference key="object" ref="233349765"/>
-						<reference key="parent" ref="402415888"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">188</int>
-						<reference key="object" ref="960025613"/>
-						<reference key="parent" ref="402415888"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">186</int>
-						<reference key="object" ref="43449478"/>
-						<reference key="parent" ref="402415888"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">183</int>
-						<reference key="object" ref="425465266"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="68071633"/>
-						</array>
-						<reference key="parent" ref="402415888"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">170</int>
-						<reference key="object" ref="155506199"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="632146717"/>
-						</array>
-						<reference key="parent" ref="402415888"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">166</int>
-						<reference key="object" ref="272186419"/>
-						<reference key="parent" ref="402415888"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">164</int>
-						<reference key="object" ref="44557163"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="511391313"/>
-						</array>
-						<reference key="parent" ref="402415888"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">160</int>
-						<reference key="object" ref="369930811"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="418582562"/>
-						</array>
-						<reference key="parent" ref="402415888"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">159</int>
-						<reference key="object" ref="103645729"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="324254028"/>
-						</array>
-						<reference key="parent" ref="402415888"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">157</int>
-						<reference key="object" ref="180153678"/>
-						<reference key="parent" ref="402415888"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">153</int>
-						<reference key="object" ref="1038163933"/>
-						<reference key="parent" ref="402415888"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">151</int>
-						<reference key="object" ref="824992908"/>
-						<reference key="parent" ref="402415888"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">146</int>
-						<reference key="object" ref="514898890"/>
-						<reference key="parent" ref="402415888"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">142</int>
-						<reference key="object" ref="83455403"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="674571607"/>
-						</array>
-						<reference key="parent" ref="402415888"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">139</int>
-						<reference key="object" ref="795324312"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="175839490"/>
-						</array>
-						<reference key="parent" ref="402415888"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">122</int>
-						<reference key="object" ref="222278178"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="485807180"/>
-						</array>
-						<reference key="parent" ref="402415888"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">121</int>
-						<reference key="object" ref="511299136"/>
-						<reference key="parent" ref="402415888"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">120</int>
-						<reference key="object" ref="271561416"/>
-						<reference key="parent" ref="402415888"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">115</int>
-						<reference key="object" ref="409264205"/>
-						<reference key="parent" ref="402415888"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">109</int>
-						<reference key="object" ref="23368208"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="349282212"/>
-						</array>
-						<reference key="parent" ref="402415888"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">108</int>
-						<reference key="object" ref="690043882"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="708814508"/>
-						</array>
-						<reference key="parent" ref="402415888"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">100</int>
-						<reference key="object" ref="650187603"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="719155945"/>
-						</array>
-						<reference key="parent" ref="402415888"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">96</int>
-						<reference key="object" ref="727596136"/>
-						<reference key="parent" ref="402415888"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">94</int>
-						<reference key="object" ref="648433288"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="235564002"/>
-						</array>
-						<reference key="parent" ref="402415888"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">90</int>
-						<reference key="object" ref="684434690"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="752262986"/>
-						</array>
-						<reference key="parent" ref="402415888"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">88</int>
-						<reference key="object" ref="193332999"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="991339367"/>
-						</array>
-						<reference key="parent" ref="402415888"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">69</int>
-						<reference key="object" ref="686202698"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="415716680"/>
-						</array>
-						<reference key="parent" ref="402415888"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">66</int>
-						<reference key="object" ref="68055949"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="716683096"/>
-						</array>
-						<reference key="parent" ref="402415888"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">61</int>
-						<reference key="object" ref="504661049"/>
-						<reference key="parent" ref="402415888"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">59</int>
-						<reference key="object" ref="118049744"/>
-						<reference key="parent" ref="402415888"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">42</int>
-						<reference key="object" ref="772434347"/>
-						<reference key="parent" ref="402415888"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">39</int>
-						<reference key="object" ref="854857905"/>
-						<reference key="parent" ref="402415888"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">37</int>
-						<reference key="object" ref="958081887"/>
-						<reference key="parent" ref="402415888"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">34</int>
-						<reference key="object" ref="722652568"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="742588452"/>
-						</array>
-						<reference key="parent" ref="402415888"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">29</int>
-						<reference key="object" ref="310238798"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="930614570"/>
-						</array>
-						<reference key="parent" ref="402415888"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">27</int>
-						<reference key="object" ref="513306894"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="154238410"/>
-						</array>
-						<reference key="parent" ref="402415888"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">25</int>
-						<reference key="object" ref="411107394"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="1014148869"/>
-						</array>
-						<reference key="parent" ref="402415888"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">23</int>
-						<reference key="object" ref="140668850"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="266134953"/>
-						</array>
-						<reference key="parent" ref="402415888"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">20</int>
-						<reference key="object" ref="638265677"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="881833546"/>
-						</array>
-						<reference key="parent" ref="402415888"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">15</int>
-						<reference key="object" ref="340464604"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="445066095"/>
-						</array>
-						<reference key="parent" ref="402415888"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">12</int>
-						<reference key="object" ref="1055210306"/>
-						<reference key="parent" ref="402415888"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">7</int>
-						<reference key="object" ref="500715027"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="384183697"/>
-						</array>
-						<reference key="parent" ref="402415888"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">6</int>
-						<reference key="object" ref="1063522251"/>
-						<reference key="parent" ref="402415888"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">450</int>
-						<reference key="object" ref="384183697"/>
-						<reference key="parent" ref="500715027"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">451</int>
-						<reference key="object" ref="445066095"/>
-						<reference key="parent" ref="340464604"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">452</int>
-						<reference key="object" ref="881833546"/>
-						<reference key="parent" ref="638265677"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">453</int>
-						<reference key="object" ref="266134953"/>
-						<reference key="parent" ref="140668850"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">454</int>
-						<reference key="object" ref="1014148869"/>
-						<reference key="parent" ref="411107394"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">455</int>
-						<reference key="object" ref="154238410"/>
-						<reference key="parent" ref="513306894"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">456</int>
-						<reference key="object" ref="930614570"/>
-						<reference key="parent" ref="310238798"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">457</int>
-						<reference key="object" ref="742588452"/>
-						<reference key="parent" ref="722652568"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">458</int>
-						<reference key="object" ref="716683096"/>
-						<reference key="parent" ref="68055949"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">459</int>
-						<reference key="object" ref="415716680"/>
-						<reference key="parent" ref="686202698"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">460</int>
-						<reference key="object" ref="991339367"/>
-						<reference key="parent" ref="193332999"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">461</int>
-						<reference key="object" ref="752262986"/>
-						<reference key="parent" ref="684434690"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">462</int>
-						<reference key="object" ref="235564002"/>
-						<reference key="parent" ref="648433288"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">463</int>
-						<reference key="object" ref="719155945"/>
-						<reference key="parent" ref="650187603"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">464</int>
-						<reference key="object" ref="708814508"/>
-						<reference key="parent" ref="690043882"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">465</int>
-						<reference key="object" ref="349282212"/>
-						<reference key="parent" ref="23368208"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">466</int>
-						<reference key="object" ref="485807180"/>
-						<reference key="parent" ref="222278178"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">467</int>
-						<reference key="object" ref="175839490"/>
-						<reference key="parent" ref="795324312"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">468</int>
-						<reference key="object" ref="674571607"/>
-						<reference key="parent" ref="83455403"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">469</int>
-						<reference key="object" ref="324254028"/>
-						<reference key="parent" ref="103645729"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">470</int>
-						<reference key="object" ref="418582562"/>
-						<reference key="parent" ref="369930811"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">471</int>
-						<reference key="object" ref="511391313"/>
-						<reference key="parent" ref="44557163"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">472</int>
-						<reference key="object" ref="632146717"/>
-						<reference key="parent" ref="155506199"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">473</int>
-						<reference key="object" ref="68071633"/>
-						<reference key="parent" ref="425465266"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">474</int>
-						<reference key="object" ref="558234484"/>
-						<reference key="parent" ref="957933488"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">475</int>
-						<reference key="object" ref="373482299"/>
-						<reference key="parent" ref="925310567"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">77</int>
-						<reference key="object" ref="820917927"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="309106554"/>
-							<reference ref="647588713"/>
-							<reference ref="446924427"/>
-							<reference ref="787268415"/>
-							<reference ref="118189423"/>
-							<reference ref="220142712"/>
-							<reference ref="317580382"/>
-							<reference ref="237037613"/>
-							<reference ref="299610555"/>
-							<reference ref="1055300200"/>
-							<reference ref="859866171"/>
-							<reference ref="754076012"/>
-							<reference ref="601992312"/>
-							<reference ref="1021883353"/>
-							<reference ref="375046315"/>
-							<reference ref="100869595"/>
-							<reference ref="1018209368"/>
-							<reference ref="1005457499"/>
-							<reference ref="73004003"/>
-							<reference ref="449540546"/>
-						</array>
-						<reference key="parent" ref="40875324"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">214</int>
-						<reference key="object" ref="787268415"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="561992552"/>
-						</array>
-						<reference key="parent" ref="820917927"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">209</int>
-						<reference key="object" ref="1018209368"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="215960604"/>
-						</array>
-						<reference key="parent" ref="820917927"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">204</int>
-						<reference key="object" ref="118189423"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="642003061"/>
-						</array>
-						<reference key="parent" ref="820917927"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">134</int>
-						<reference key="object" ref="375046315"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="397070298"/>
-						</array>
-						<reference key="parent" ref="820917927"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">113</int>
-						<reference key="object" ref="859866171"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="1050250763"/>
-						</array>
-						<reference key="parent" ref="820917927"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">97</int>
-						<reference key="object" ref="754076012"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="46483213"/>
-						</array>
-						<reference key="parent" ref="820917927"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">93</int>
-						<reference key="object" ref="601992312"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="744867520"/>
-						</array>
-						<reference key="parent" ref="820917927"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">86</int>
-						<reference key="object" ref="647588713"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="284031237"/>
-						</array>
-						<reference key="parent" ref="820917927"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">54</int>
-						<reference key="object" ref="1021883353"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="200405955"/>
-						</array>
-						<reference key="parent" ref="820917927"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">36</int>
-						<reference key="object" ref="1055300200"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="557873526"/>
-						</array>
-						<reference key="parent" ref="820917927"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">11</int>
-						<reference key="object" ref="446924427"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="702610801"/>
-						</array>
-						<reference key="parent" ref="820917927"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">5</int>
-						<reference key="object" ref="100869595"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="580378339"/>
-						</array>
-						<reference key="parent" ref="820917927"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">476</int>
-						<reference key="object" ref="580378339"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="998492064"/>
-						</array>
-						<reference key="parent" ref="100869595"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">82</int>
-						<reference key="object" ref="998492064"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="524656986"/>
-							<reference ref="158703308"/>
-							<reference ref="878449292"/>
-							<reference ref="239081209"/>
-						</array>
-						<reference key="parent" ref="580378339"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">130</int>
-						<reference key="object" ref="524656986"/>
-						<reference key="parent" ref="998492064"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">143</int>
-						<reference key="object" ref="158703308"/>
-						<reference key="parent" ref="998492064"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">179</int>
-						<reference key="object" ref="878449292"/>
-						<reference key="parent" ref="998492064"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">182</int>
-						<reference key="object" ref="239081209"/>
-						<reference key="parent" ref="998492064"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">477</int>
-						<reference key="object" ref="702610801"/>
-						<reference key="parent" ref="446924427"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">478</int>
-						<reference key="object" ref="557873526"/>
-						<reference key="parent" ref="1055300200"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">479</int>
-						<reference key="object" ref="200405955"/>
-						<reference key="parent" ref="1021883353"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">480</int>
-						<reference key="object" ref="284031237"/>
-						<reference key="parent" ref="647588713"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">481</int>
-						<reference key="object" ref="744867520"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="506597454"/>
-						</array>
-						<reference key="parent" ref="601992312"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">78</int>
-						<reference key="object" ref="506597454"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="419088361"/>
-							<reference ref="507982522"/>
-						</array>
-						<reference key="parent" ref="744867520"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">124</int>
-						<reference key="object" ref="419088361"/>
-						<reference key="parent" ref="506597454"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">148</int>
-						<reference key="object" ref="507982522"/>
-						<reference key="parent" ref="506597454"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">482</int>
-						<reference key="object" ref="46483213"/>
-						<reference key="parent" ref="754076012"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">483</int>
-						<reference key="object" ref="1050250763"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="778662096"/>
-						</array>
-						<reference key="parent" ref="859866171"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">149</int>
-						<reference key="object" ref="778662096"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="320237679"/>
-							<reference ref="513519977"/>
-						</array>
-						<reference key="parent" ref="1050250763"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">10</int>
-						<reference key="object" ref="320237679"/>
-						<reference key="parent" ref="778662096"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">140</int>
-						<reference key="object" ref="513519977"/>
-						<reference key="parent" ref="778662096"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">484</int>
-						<reference key="object" ref="397070298"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="169570948"/>
-						</array>
-						<reference key="parent" ref="375046315"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">30</int>
-						<reference key="object" ref="169570948"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="655875288"/>
-							<reference ref="457365082"/>
-						</array>
-						<reference key="parent" ref="397070298"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">132</int>
-						<reference key="object" ref="655875288"/>
-						<reference key="parent" ref="169570948"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">174</int>
-						<reference key="object" ref="457365082"/>
-						<reference key="parent" ref="169570948"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">485</int>
-						<reference key="object" ref="642003061"/>
-						<reference key="parent" ref="118189423"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">486</int>
-						<reference key="object" ref="215960604"/>
-						<reference key="parent" ref="1018209368"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">487</int>
-						<reference key="object" ref="561992552"/>
-						<reference key="parent" ref="787268415"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">76</int>
-						<reference key="object" ref="57587199"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="755493711"/>
-							<reference ref="288449918"/>
-							<reference ref="311410408"/>
-							<reference ref="102143362"/>
-							<reference ref="140016662"/>
-							<reference ref="367266019"/>
-							<reference ref="325970917"/>
-							<reference ref="363290500"/>
-							<reference ref="546974449"/>
-							<reference ref="555959875"/>
-							<reference ref="506678724"/>
-						</array>
-						<reference key="parent" ref="513972833"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">217</int>
-						<reference key="object" ref="140016662"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="743545524"/>
-						</array>
-						<reference key="parent" ref="57587199"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">201</int>
-						<reference key="object" ref="288449918"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="192041138"/>
-						</array>
-						<reference key="parent" ref="57587199"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">177</int>
-						<reference key="object" ref="102143362"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="573470832"/>
-						</array>
-						<reference key="parent" ref="57587199"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">158</int>
-						<reference key="object" ref="367266019"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="85520379"/>
-						</array>
-						<reference key="parent" ref="57587199"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">150</int>
-						<reference key="object" ref="311410408"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="908723235"/>
-						</array>
-						<reference key="parent" ref="57587199"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">46</int>
-						<reference key="object" ref="325970917"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="242317460"/>
-						</array>
-						<reference key="parent" ref="57587199"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">491</int>
-						<reference key="object" ref="242317460"/>
-						<reference key="parent" ref="325970917"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">492</int>
-						<reference key="object" ref="908723235"/>
-						<reference key="parent" ref="311410408"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">493</int>
-						<reference key="object" ref="85520379"/>
-						<reference key="parent" ref="367266019"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">494</int>
-						<reference key="object" ref="573470832"/>
-						<reference key="parent" ref="102143362"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">495</int>
-						<reference key="object" ref="192041138"/>
-						<reference key="parent" ref="288449918"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">496</int>
-						<reference key="object" ref="743545524"/>
-						<reference key="parent" ref="140016662"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">190</int>
-						<reference key="object" ref="715816214"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="117700411"/>
-							<reference ref="17670746"/>
-							<reference ref="1007387692"/>
-							<reference ref="415446463"/>
-							<reference ref="16204397"/>
-							<reference ref="15380591"/>
-							<reference ref="713131109"/>
-							<reference ref="195567578"/>
-							<reference ref="312647408"/>
-							<reference ref="619505271"/>
-							<reference ref="232859697"/>
-							<reference ref="452140972"/>
-							<reference ref="180817061"/>
-							<reference ref="40697488"/>
-							<reference ref="206913966"/>
-							<reference ref="492037363"/>
-							<reference ref="1017938941"/>
-							<reference ref="69632604"/>
-							<reference ref="823087564"/>
-							<reference ref="477134160"/>
-							<reference ref="8070843"/>
-							<reference ref="940489567"/>
-							<reference ref="263160901"/>
-							<reference ref="539390510"/>
-							<reference ref="228398657"/>
-							<reference ref="781764471"/>
-							<reference ref="311130897"/>
-						</array>
-						<reference key="parent" ref="815118087"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">213</int>
-						<reference key="object" ref="1017938941"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="182722506"/>
-						</array>
-						<reference key="parent" ref="715816214"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">205</int>
-						<reference key="object" ref="69632604"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="871050368"/>
-						</array>
-						<reference key="parent" ref="715816214"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">194</int>
-						<reference key="object" ref="823087564"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="627787601"/>
-						</array>
-						<reference key="parent" ref="715816214"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">180</int>
-						<reference key="object" ref="477134160"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="592705779"/>
-						</array>
-						<reference key="parent" ref="715816214"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">167</int>
-						<reference key="object" ref="206913966"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="377830616"/>
-						</array>
-						<reference key="parent" ref="715816214"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">163</int>
-						<reference key="object" ref="452140972"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="853966779"/>
-						</array>
-						<reference key="parent" ref="715816214"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">145</int>
-						<reference key="object" ref="117700411"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="939822168"/>
-						</array>
-						<reference key="parent" ref="715816214"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">137</int>
-						<reference key="object" ref="492037363"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="1069924385"/>
-						</array>
-						<reference key="parent" ref="715816214"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">133</int>
-						<reference key="object" ref="713131109"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="429483781"/>
-						</array>
-						<reference key="parent" ref="715816214"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">105</int>
-						<reference key="object" ref="15380591"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="280211799"/>
-						</array>
-						<reference key="parent" ref="715816214"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">83</int>
-						<reference key="object" ref="40697488"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="470434084"/>
-						</array>
-						<reference key="parent" ref="715816214"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">74</int>
-						<reference key="object" ref="180817061"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="982821600"/>
-						</array>
-						<reference key="parent" ref="715816214"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">72</int>
-						<reference key="object" ref="17670746"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="80801900"/>
-						</array>
-						<reference key="parent" ref="715816214"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">57</int>
-						<reference key="object" ref="8070843"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="787527069"/>
-						</array>
-						<reference key="parent" ref="715816214"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">18</int>
-						<reference key="object" ref="1007387692"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="17521243"/>
-						</array>
-						<reference key="parent" ref="715816214"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">497</int>
-						<reference key="object" ref="17521243"/>
-						<reference key="parent" ref="1007387692"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">498</int>
-						<reference key="object" ref="787527069"/>
-						<reference key="parent" ref="8070843"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">500</int>
-						<reference key="object" ref="80801900"/>
-						<reference key="parent" ref="17670746"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">501</int>
-						<reference key="object" ref="982821600"/>
-						<reference key="parent" ref="180817061"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">502</int>
-						<reference key="object" ref="470434084"/>
-						<reference key="parent" ref="40697488"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">504</int>
-						<reference key="object" ref="280211799"/>
-						<reference key="parent" ref="15380591"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">506</int>
-						<reference key="object" ref="429483781"/>
-						<reference key="parent" ref="713131109"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">507</int>
-						<reference key="object" ref="1069924385"/>
-						<reference key="parent" ref="492037363"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">508</int>
-						<reference key="object" ref="939822168"/>
-						<reference key="parent" ref="117700411"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">510</int>
-						<reference key="object" ref="853966779"/>
-						<reference key="parent" ref="452140972"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">511</int>
-						<reference key="object" ref="377830616"/>
-						<reference key="parent" ref="206913966"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">512</int>
-						<reference key="object" ref="592705779"/>
-						<reference key="parent" ref="477134160"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">513</int>
-						<reference key="object" ref="627787601"/>
-						<reference key="parent" ref="823087564"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">514</int>
-						<reference key="object" ref="871050368"/>
-						<reference key="parent" ref="69632604"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">516</int>
-						<reference key="object" ref="182722506"/>
-						<reference key="parent" ref="1017938941"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">21</int>
-						<reference key="object" ref="131199459"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="182242525"/>
-							<reference ref="14999216"/>
-							<reference ref="922446711"/>
-							<reference ref="533989164"/>
-							<reference ref="787415205"/>
-							<reference ref="576326782"/>
-							<reference ref="687146077"/>
-							<reference ref="1054086864"/>
-							<reference ref="633912981"/>
-							<reference ref="975592998"/>
-							<reference ref="291755447"/>
-							<reference ref="255235135"/>
-							<reference ref="199654805"/>
-							<reference ref="858794840"/>
-							<reference ref="241602288"/>
-							<reference ref="823414242"/>
-							<reference ref="887471351"/>
-							<reference ref="1048498102"/>
-							<reference ref="317149642"/>
-							<reference ref="475001756"/>
-							<reference ref="1062025260"/>
-							<reference ref="250273303"/>
-							<reference ref="410813163"/>
-							<reference ref="422271573"/>
-							<reference ref="720402574"/>
-						</array>
-						<reference key="parent" ref="410501168"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">207</int>
-						<reference key="object" ref="1054086864"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="63375091"/>
-						</array>
-						<reference key="parent" ref="131199459"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">189</int>
-						<reference key="object" ref="1062025260"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="227305221"/>
-						</array>
-						<reference key="parent" ref="131199459"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">181</int>
-						<reference key="object" ref="633912981"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="673395531"/>
-						</array>
-						<reference key="parent" ref="131199459"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">178</int>
-						<reference key="object" ref="720402574"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="806919615"/>
-						</array>
-						<reference key="parent" ref="131199459"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">172</int>
-						<reference key="object" ref="14999216"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="419343362"/>
-						</array>
-						<reference key="parent" ref="131199459"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">171</int>
-						<reference key="object" ref="410813163"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="173122541"/>
-						</array>
-						<reference key="parent" ref="131199459"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">138</int>
-						<reference key="object" ref="291755447"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="41867835"/>
-						</array>
-						<reference key="parent" ref="131199459"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">104</int>
-						<reference key="object" ref="975592998"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="254322774"/>
-						</array>
-						<reference key="parent" ref="131199459"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">103</int>
-						<reference key="object" ref="576326782"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="415439001"/>
-						</array>
-						<reference key="parent" ref="131199459"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">101</int>
-						<reference key="object" ref="422271573"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="834827122"/>
-						</array>
-						<reference key="parent" ref="131199459"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">85</int>
-						<reference key="object" ref="687146077"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="243539596"/>
-						</array>
-						<reference key="parent" ref="131199459"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">58</int>
-						<reference key="object" ref="182242525"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="598158509"/>
-						</array>
-						<reference key="parent" ref="131199459"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">16</int>
-						<reference key="object" ref="250273303"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="1043349204"/>
-						</array>
-						<reference key="parent" ref="131199459"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">519</int>
-						<reference key="object" ref="1043349204"/>
-						<reference key="parent" ref="250273303"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">520</int>
-						<reference key="object" ref="598158509"/>
-						<reference key="parent" ref="182242525"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">521</int>
-						<reference key="object" ref="243539596"/>
-						<reference key="parent" ref="687146077"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">522</int>
-						<reference key="object" ref="834827122"/>
-						<reference key="parent" ref="422271573"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">523</int>
-						<reference key="object" ref="415439001"/>
-						<reference key="parent" ref="576326782"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">524</int>
-						<reference key="object" ref="254322774"/>
-						<reference key="parent" ref="975592998"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">526</int>
-						<reference key="object" ref="41867835"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="736055343"/>
-						</array>
-						<reference key="parent" ref="291755447"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">117</int>
-						<reference key="object" ref="736055343"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="40846141"/>
-							<reference ref="659020466"/>
-							<reference ref="152202287"/>
-							<reference ref="562311160"/>
-							<reference ref="418675757"/>
-						</array>
-						<reference key="parent" ref="41867835"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">32</int>
-						<reference key="object" ref="40846141"/>
-						<reference key="parent" ref="736055343"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">75</int>
-						<reference key="object" ref="659020466"/>
-						<reference key="parent" ref="736055343"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">175</int>
-						<reference key="object" ref="152202287"/>
-						<reference key="parent" ref="736055343"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">197</int>
-						<reference key="object" ref="562311160"/>
-						<reference key="parent" ref="736055343"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">208</int>
-						<reference key="object" ref="418675757"/>
-						<reference key="parent" ref="736055343"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">527</int>
-						<reference key="object" ref="173122541"/>
-						<reference key="parent" ref="410813163"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">528</int>
-						<reference key="object" ref="419343362"/>
-						<reference key="parent" ref="14999216"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">529</int>
-						<reference key="object" ref="806919615"/>
-						<reference key="parent" ref="720402574"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">530</int>
-						<reference key="object" ref="673395531"/>
-						<reference key="parent" ref="633912981"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">531</int>
-						<reference key="object" ref="227305221"/>
-						<reference key="parent" ref="1062025260"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">532</int>
-						<reference key="object" ref="63375091"/>
-						<reference key="parent" ref="1054086864"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">144</int>
-						<reference key="object" ref="528799783"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="296311144"/>
-							<reference ref="879421054"/>
-							<reference ref="298337413"/>
-							<reference ref="117258399"/>
-							<reference ref="819029281"/>
-							<reference ref="100091316"/>
-							<reference ref="391437494"/>
-							<reference ref="617259440"/>
-							<reference ref="677491028"/>
-							<reference ref="615357857"/>
-							<reference ref="86962169"/>
-							<reference ref="713833474"/>
-							<reference ref="324798199"/>
-							<reference ref="455996658"/>
-							<reference ref="243082559"/>
-							<reference ref="409395540"/>
-							<reference ref="536293017"/>
-							<reference ref="724103728"/>
-						</array>
-						<reference key="parent" ref="82298705"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">372</int>
-						<reference key="object" ref="409395540"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="1006168066"/>
-						</array>
-						<reference key="parent" ref="528799783"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">371</int>
-						<reference key="object" ref="243082559"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="349793878"/>
-						</array>
-						<reference key="parent" ref="528799783"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">223</int>
-						<reference key="object" ref="455996658"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="284754102"/>
-						</array>
-						<reference key="parent" ref="528799783"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">211</int>
-						<reference key="object" ref="677491028"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="1002348628"/>
-						</array>
-						<reference key="parent" ref="528799783"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">206</int>
-						<reference key="object" ref="819029281"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="159123237"/>
-						</array>
-						<reference key="parent" ref="528799783"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">195</int>
-						<reference key="object" ref="879421054"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="779276659"/>
-						</array>
-						<reference key="parent" ref="528799783"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">176</int>
-						<reference key="object" ref="117258399"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="197314660"/>
-						</array>
-						<reference key="parent" ref="528799783"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">147</int>
-						<reference key="object" ref="713833474"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="208818602"/>
-						</array>
-						<reference key="parent" ref="528799783"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">99</int>
-						<reference key="object" ref="617259440"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="416222473"/>
-						</array>
-						<reference key="parent" ref="528799783"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">98</int>
-						<reference key="object" ref="86962169"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="223140313"/>
-						</array>
-						<reference key="parent" ref="528799783"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">71</int>
-						<reference key="object" ref="391437494"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="433742716"/>
-						</array>
-						<reference key="parent" ref="528799783"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">63</int>
-						<reference key="object" ref="324798199"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="286514404"/>
-						</array>
-						<reference key="parent" ref="528799783"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">51</int>
-						<reference key="object" ref="615357857"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="58983848"/>
-						</array>
-						<reference key="parent" ref="528799783"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">47</int>
-						<reference key="object" ref="100091316"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="33394425"/>
-						</array>
-						<reference key="parent" ref="528799783"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">28</int>
-						<reference key="object" ref="298337413"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="19692194"/>
-						</array>
-						<reference key="parent" ref="528799783"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">533</int>
-						<reference key="object" ref="19692194"/>
-						<reference key="parent" ref="298337413"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">534</int>
-						<reference key="object" ref="33394425"/>
-						<reference key="parent" ref="100091316"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">535</int>
-						<reference key="object" ref="58983848"/>
-						<reference key="parent" ref="615357857"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">536</int>
-						<reference key="object" ref="286514404"/>
-						<reference key="parent" ref="324798199"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">537</int>
-						<reference key="object" ref="433742716"/>
-						<reference key="parent" ref="391437494"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">539</int>
-						<reference key="object" ref="223140313"/>
-						<reference key="parent" ref="86962169"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">540</int>
-						<reference key="object" ref="416222473"/>
-						<reference key="parent" ref="617259440"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">544</int>
-						<reference key="object" ref="208818602"/>
-						<reference key="parent" ref="713833474"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">545</int>
-						<reference key="object" ref="197314660"/>
-						<reference key="parent" ref="117258399"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">547</int>
-						<reference key="object" ref="779276659"/>
-						<reference key="parent" ref="879421054"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">548</int>
-						<reference key="object" ref="159123237"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="254801121"/>
-						</array>
-						<reference key="parent" ref="819029281"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">45</int>
-						<reference key="object" ref="254801121"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="404305924"/>
-							<reference ref="912128190"/>
-							<reference ref="732647984"/>
-						</array>
-						<reference key="parent" ref="159123237"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">43</int>
-						<reference key="object" ref="404305924"/>
-						<reference key="parent" ref="254801121"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">173</int>
-						<reference key="object" ref="912128190"/>
-						<reference key="parent" ref="254801121"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">192</int>
-						<reference key="object" ref="732647984"/>
-						<reference key="parent" ref="254801121"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">549</int>
-						<reference key="object" ref="1002348628"/>
-						<reference key="parent" ref="677491028"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">550</int>
-						<reference key="object" ref="284754102"/>
-						<reference key="parent" ref="455996658"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">551</int>
-						<reference key="object" ref="349793878"/>
-						<reference key="parent" ref="243082559"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">552</int>
-						<reference key="object" ref="1006168066"/>
-						<reference key="parent" ref="409395540"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">60</int>
-						<reference key="object" ref="19718304"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="450481229"/>
-							<reference ref="443451250"/>
-							<reference ref="846995571"/>
-							<reference ref="702422028"/>
-							<reference ref="843004622"/>
-							<reference ref="544344533"/>
-							<reference ref="1030426936"/>
-							<reference ref="367627207"/>
-							<reference ref="86511413"/>
-							<reference ref="67211373"/>
-							<reference ref="207844218"/>
-							<reference ref="406095088"/>
-							<reference ref="842802870"/>
-							<reference ref="542998689"/>
-						</array>
-						<reference key="parent" ref="1040782865"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">225</int>
-						<reference key="object" ref="207844218"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="621951969"/>
-						</array>
-						<reference key="parent" ref="19718304"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">215</int>
-						<reference key="object" ref="544344533"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="893064887"/>
-						</array>
-						<reference key="parent" ref="19718304"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">161</int>
-						<reference key="object" ref="702422028"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="673213488"/>
-						</array>
-						<reference key="parent" ref="19718304"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">129</int>
-						<reference key="object" ref="842802870"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="976186580"/>
-						</array>
-						<reference key="parent" ref="19718304"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">127</int>
-						<reference key="object" ref="67211373"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="146368653"/>
-						</array>
-						<reference key="parent" ref="19718304"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">102</int>
-						<reference key="object" ref="843004622"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="642818869"/>
-						</array>
-						<reference key="parent" ref="19718304"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">13</int>
-						<reference key="object" ref="443451250"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="1017031721"/>
-						</array>
-						<reference key="parent" ref="19718304"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">553</int>
-						<reference key="object" ref="1017031721"/>
-						<reference key="parent" ref="443451250"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">554</int>
-						<reference key="object" ref="642818869"/>
-						<reference key="parent" ref="843004622"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">555</int>
-						<reference key="object" ref="146368653"/>
-						<reference key="parent" ref="67211373"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">556</int>
-						<reference key="object" ref="976186580"/>
-						<reference key="parent" ref="842802870"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">557</int>
-						<reference key="object" ref="673213488"/>
-						<reference key="parent" ref="702422028"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">558</int>
-						<reference key="object" ref="893064887"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="215914061"/>
-						</array>
-						<reference key="parent" ref="544344533"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">216</int>
-						<reference key="object" ref="215914061"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="298569940"/>
-							<reference ref="131388204"/>
-							<reference ref="361965654"/>
-							<reference ref="54656864"/>
-							<reference ref="230994184"/>
-						</array>
-						<reference key="parent" ref="893064887"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">8</int>
-						<reference key="object" ref="298569940"/>
-						<reference key="parent" ref="215914061"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">68</int>
-						<reference key="object" ref="131388204"/>
-						<reference key="parent" ref="215914061"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">79</int>
-						<reference key="object" ref="361965654"/>
-						<reference key="parent" ref="215914061"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">200</int>
-						<reference key="object" ref="54656864"/>
-						<reference key="parent" ref="215914061"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">219</int>
-						<reference key="object" ref="230994184"/>
-						<reference key="parent" ref="215914061"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">559</int>
-						<reference key="object" ref="621951969"/>
-						<reference key="parent" ref="207844218"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">187</int>
-						<reference key="object" ref="416415920"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="489866395"/>
-							<reference ref="625485372"/>
-							<reference ref="186360774"/>
-							<reference ref="1049155740"/>
-							<reference ref="1064535331"/>
-							<reference ref="534115331"/>
-							<reference ref="515286899"/>
-							<reference ref="454194464"/>
-							<reference ref="890839872"/>
-							<reference ref="1031487992"/>
-							<reference ref="1068694386"/>
-							<reference ref="824226409"/>
-							<reference ref="448930768"/>
-							<reference ref="257956724"/>
-							<reference ref="667026855"/>
-						</array>
-						<reference key="parent" ref="882238021"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">413</int>
-						<reference key="object" ref="448930768"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="1005042470"/>
-						</array>
-						<reference key="parent" ref="416415920"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">412</int>
-						<reference key="object" ref="824226409"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="481179084"/>
-						</array>
-						<reference key="parent" ref="416415920"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">354</int>
-						<reference key="object" ref="515286899"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="646718756"/>
-						</array>
-						<reference key="parent" ref="416415920"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">220</int>
-						<reference key="object" ref="1049155740"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="159598989"/>
-						</array>
-						<reference key="parent" ref="416415920"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">203</int>
-						<reference key="object" ref="1068694386"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="186711920"/>
-						</array>
-						<reference key="parent" ref="416415920"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">155</int>
-						<reference key="object" ref="186360774"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="844032417"/>
-						</array>
-						<reference key="parent" ref="416415920"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">128</int>
-						<reference key="object" ref="890839872"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="368416592"/>
-						</array>
-						<reference key="parent" ref="416415920"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">92</int>
-						<reference key="object" ref="534115331"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="522132494"/>
-						</array>
-						<reference key="parent" ref="416415920"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">70</int>
-						<reference key="object" ref="1031487992"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="438036338"/>
-						</array>
-						<reference key="parent" ref="416415920"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">14</int>
-						<reference key="object" ref="1064535331"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="486311972"/>
-						</array>
-						<reference key="parent" ref="416415920"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">9</int>
-						<reference key="object" ref="625485372"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="938351969"/>
-						</array>
-						<reference key="parent" ref="416415920"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">560</int>
-						<reference key="object" ref="938351969"/>
-						<reference key="parent" ref="625485372"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">561</int>
-						<reference key="object" ref="486311972"/>
-						<reference key="parent" ref="1064535331"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">562</int>
-						<reference key="object" ref="438036338"/>
-						<reference key="parent" ref="1031487992"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">563</int>
-						<reference key="object" ref="522132494"/>
-						<reference key="parent" ref="534115331"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">564</int>
-						<reference key="object" ref="368416592"/>
-						<reference key="parent" ref="890839872"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">565</int>
-						<reference key="object" ref="844032417"/>
-						<reference key="parent" ref="186360774"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">566</int>
-						<reference key="object" ref="186711920"/>
-						<reference key="parent" ref="1068694386"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">567</int>
-						<reference key="object" ref="159598989"/>
-						<reference key="parent" ref="1049155740"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">568</int>
-						<reference key="object" ref="646718756"/>
-						<reference key="parent" ref="515286899"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">569</int>
-						<reference key="object" ref="481179084"/>
-						<reference key="parent" ref="824226409"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">570</int>
-						<reference key="object" ref="1005042470"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="82319767"/>
-						</array>
-						<reference key="parent" ref="448930768"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">414</int>
-						<reference key="object" ref="82319767"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="601422765"/>
-							<reference ref="661175652"/>
-						</array>
-						<reference key="parent" ref="1005042470"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">415</int>
-						<reference key="object" ref="601422765"/>
-						<reference key="parent" ref="82319767"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">416</int>
-						<reference key="object" ref="661175652"/>
-						<reference key="parent" ref="82319767"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">314</int>
-						<reference key="object" ref="208408466"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="825536519"/>
-							<reference ref="281284938"/>
-							<reference ref="415497060"/>
-							<reference ref="783182166"/>
-							<reference ref="500047584"/>
-							<reference ref="724602615"/>
-							<reference ref="813833386"/>
-						</array>
-						<reference key="parent" ref="700045870"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">369</int>
-						<reference key="object" ref="724602615"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="317990598"/>
-						</array>
-						<reference key="parent" ref="208408466"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">368</int>
-						<reference key="object" ref="500047584"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="298350863"/>
-						</array>
-						<reference key="parent" ref="208408466"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">367</int>
-						<reference key="object" ref="783182166"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="947689056"/>
-						</array>
-						<reference key="parent" ref="208408466"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">366</int>
-						<reference key="object" ref="415497060"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="376973446"/>
-						</array>
-						<reference key="parent" ref="208408466"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">365</int>
-						<reference key="object" ref="281284938"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="331744288"/>
-						</array>
-						<reference key="parent" ref="208408466"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">316</int>
-						<reference key="object" ref="825536519"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="577402709"/>
-							<reference ref="1011610652"/>
-							<reference ref="754821796"/>
-							<reference ref="932713766"/>
-						</array>
-						<reference key="parent" ref="208408466"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">588</int>
-						<reference key="object" ref="577402709"/>
-						<reference key="parent" ref="825536519"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">587</int>
-						<reference key="object" ref="1011610652"/>
-						<reference key="parent" ref="825536519"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">586</int>
-						<reference key="object" ref="754821796"/>
-						<reference key="parent" ref="825536519"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">317</int>
-						<reference key="object" ref="932713766"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="967380251"/>
-							<reference ref="855298656"/>
-							<reference ref="538257256"/>
-							<reference ref="805764618"/>
-							<reference ref="514204815"/>
-						</array>
-						<reference key="parent" ref="825536519"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">364</int>
-						<reference key="object" ref="967380251"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="86467400"/>
-						</array>
-						<reference key="parent" ref="932713766"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">363</int>
-						<reference key="object" ref="855298656"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="405234283"/>
-						</array>
-						<reference key="parent" ref="932713766"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">362</int>
-						<reference key="object" ref="538257256"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="416647572"/>
-						</array>
-						<reference key="parent" ref="932713766"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">318</int>
-						<reference key="object" ref="805764618"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="232833055"/>
-						</array>
-						<reference key="parent" ref="932713766"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">315</int>
-						<reference key="object" ref="514204815"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="1048052152"/>
-						</array>
-						<reference key="parent" ref="932713766"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">580</int>
-						<reference key="object" ref="1048052152"/>
-						<reference key="parent" ref="514204815"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">581</int>
-						<reference key="object" ref="232833055"/>
-						<reference key="parent" ref="805764618"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">582</int>
-						<reference key="object" ref="416647572"/>
-						<reference key="parent" ref="538257256"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">583</int>
-						<reference key="object" ref="405234283"/>
-						<reference key="parent" ref="855298656"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">584</int>
-						<reference key="object" ref="86467400"/>
-						<reference key="parent" ref="967380251"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">571</int>
-						<reference key="object" ref="331744288"/>
-						<reference key="parent" ref="281284938"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">572</int>
-						<reference key="object" ref="376973446"/>
-						<reference key="parent" ref="415497060"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">573</int>
-						<reference key="object" ref="947689056"/>
-						<reference key="parent" ref="783182166"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">574</int>
-						<reference key="object" ref="298350863"/>
-						<reference key="parent" ref="500047584"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">575</int>
-						<reference key="object" ref="317990598"/>
-						<reference key="parent" ref="724602615"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">592</int>
-						<reference key="object" ref="427166787"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="886433215"/>
-						</array>
-						<reference key="parent" ref="55856611"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">593</int>
-						<reference key="object" ref="886433215"/>
-						<reference key="parent" ref="427166787"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">594</int>
-						<reference key="object" ref="48224885"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="917059312"/>
-						</array>
-						<reference key="parent" ref="402415888"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">595</int>
-						<reference key="object" ref="917059312"/>
-						<reference key="parent" ref="48224885"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">596</int>
-						<reference key="object" ref="687336195"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="624198228"/>
-						</array>
-						<reference key="parent" ref="402415888"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">597</int>
-						<reference key="object" ref="624198228"/>
-						<reference key="parent" ref="687336195"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">598</int>
-						<reference key="object" ref="1031955050"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="1036308174"/>
-						</array>
-						<reference key="parent" ref="402415888"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">599</int>
-						<reference key="object" ref="1036308174"/>
-						<reference key="parent" ref="1031955050"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">600</int>
-						<reference key="object" ref="787415205"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="1067897035"/>
-						</array>
-						<reference key="parent" ref="131199459"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">601</int>
-						<reference key="object" ref="1067897035"/>
-						<reference key="parent" ref="787415205"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">602</int>
-						<reference key="object" ref="533989164"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="885713094"/>
-						</array>
-						<reference key="parent" ref="131199459"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">603</int>
-						<reference key="object" ref="885713094"/>
-						<reference key="parent" ref="533989164"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">604</int>
-						<reference key="object" ref="922446711"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="27860998"/>
-						</array>
-						<reference key="parent" ref="131199459"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">605</int>
-						<reference key="object" ref="27860998"/>
-						<reference key="parent" ref="922446711"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">618</int>
-						<reference key="object" ref="940489567"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="63479885"/>
-						</array>
-						<reference key="parent" ref="715816214"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">619</int>
-						<reference key="object" ref="63479885"/>
-						<reference key="parent" ref="940489567"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">620</int>
-						<reference key="object" ref="263160901"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="684025955"/>
-						</array>
-						<reference key="parent" ref="715816214"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">621</int>
-						<reference key="object" ref="684025955"/>
-						<reference key="parent" ref="263160901"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">622</int>
-						<reference key="object" ref="415446463"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="936918162"/>
-						</array>
-						<reference key="parent" ref="715816214"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">623</int>
-						<reference key="object" ref="936918162"/>
-						<reference key="parent" ref="415446463"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">624</int>
-						<reference key="object" ref="539390510"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="1056138533"/>
-						</array>
-						<reference key="parent" ref="715816214"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">625</int>
-						<reference key="object" ref="1056138533"/>
-						<reference key="parent" ref="539390510"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">628</int>
-						<reference key="object" ref="489866395"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="455308470"/>
-						</array>
-						<reference key="parent" ref="416415920"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">629</int>
-						<reference key="object" ref="455308470"/>
-						<reference key="parent" ref="489866395"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">630</int>
-						<reference key="object" ref="454194464"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="703463092"/>
-						</array>
-						<reference key="parent" ref="416415920"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">631</int>
-						<reference key="object" ref="703463092"/>
-						<reference key="parent" ref="454194464"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">632</int>
-						<reference key="object" ref="450481229"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="616220944"/>
-						</array>
-						<reference key="parent" ref="19718304"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">633</int>
-						<reference key="object" ref="616220944"/>
-						<reference key="parent" ref="450481229"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">634</int>
-						<reference key="object" ref="406095088"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="247302629"/>
-						</array>
-						<reference key="parent" ref="19718304"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">635</int>
-						<reference key="object" ref="247302629"/>
-						<reference key="parent" ref="406095088"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">636</int>
-						<reference key="object" ref="73004003"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="220904047"/>
-						</array>
-						<reference key="parent" ref="820917927"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">637</int>
-						<reference key="object" ref="220904047"/>
-						<reference key="parent" ref="73004003"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">638</int>
-						<reference key="object" ref="755493711"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="510828702"/>
-						</array>
-						<reference key="parent" ref="57587199"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">639</int>
-						<reference key="object" ref="510828702"/>
-						<reference key="parent" ref="755493711"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">640</int>
-						<reference key="object" ref="363290500"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="114048374"/>
-						</array>
-						<reference key="parent" ref="57587199"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">641</int>
-						<reference key="object" ref="114048374"/>
-						<reference key="parent" ref="363290500"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">642</int>
-						<reference key="object" ref="546974449"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="484063948"/>
-						</array>
-						<reference key="parent" ref="57587199"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">643</int>
-						<reference key="object" ref="484063948"/>
-						<reference key="parent" ref="546974449"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">644</int>
-						<reference key="object" ref="555959875"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="926272167"/>
-						</array>
-						<reference key="parent" ref="57587199"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">645</int>
-						<reference key="object" ref="926272167"/>
-						<reference key="parent" ref="555959875"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">646</int>
-						<reference key="object" ref="296311144"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="653437884"/>
-						</array>
-						<reference key="parent" ref="528799783"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">647</int>
-						<reference key="object" ref="653437884"/>
-						<reference key="parent" ref="296311144"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">648</int>
-						<reference key="object" ref="536293017"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="107688609"/>
-						</array>
-						<reference key="parent" ref="528799783"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">649</int>
-						<reference key="object" ref="107688609"/>
-						<reference key="parent" ref="536293017"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">650</int>
-						<reference key="object" ref="724103728"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="1061114156"/>
-						</array>
-						<reference key="parent" ref="528799783"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">651</int>
-						<reference key="object" ref="1061114156"/>
-						<reference key="parent" ref="724103728"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">118</int>
-						<reference key="object" ref="309106554"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="210024465"/>
-						</array>
-						<reference key="parent" ref="820917927"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">430</int>
-						<reference key="object" ref="210024465"/>
-						<reference key="parent" ref="309106554"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">709</int>
-						<reference key="object" ref="23773977"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="150217438"/>
-						</array>
-						<reference key="parent" ref="1053574686"/>
-						<string key="objectName">Alerts</string>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">710</int>
-						<reference key="object" ref="150217438"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="967409140"/>
-							<reference ref="366330173"/>
-							<reference ref="666364138"/>
-							<reference ref="904793015"/>
-							<reference ref="1047641055"/>
-							<reference ref="746284896"/>
-							<reference ref="1057046117"/>
-							<reference ref="637075528"/>
-							<reference ref="1053086435"/>
-							<reference ref="1028551236"/>
-							<reference ref="779767674"/>
-							<reference ref="998640248"/>
-							<reference ref="962156983"/>
-						</array>
-						<reference key="parent" ref="23773977"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">154</int>
-						<reference key="object" ref="746284896"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="843263007"/>
-						</array>
-						<reference key="parent" ref="150217438"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">434</int>
-						<reference key="object" ref="843263007"/>
-						<reference key="parent" ref="746284896"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">67</int>
-						<reference key="object" ref="1057046117"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="71796614"/>
-						</array>
-						<reference key="parent" ref="150217438"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">425</int>
-						<reference key="object" ref="71796614"/>
-						<reference key="parent" ref="1057046117"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">711</int>
-						<reference key="object" ref="904793015"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="880650260"/>
-						</array>
-						<reference key="parent" ref="150217438"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">712</int>
-						<reference key="object" ref="880650260"/>
-						<reference key="parent" ref="904793015"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">713</int>
-						<reference key="object" ref="1047641055"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="694279702"/>
-						</array>
-						<reference key="parent" ref="150217438"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">714</int>
-						<reference key="object" ref="694279702"/>
-						<reference key="parent" ref="1047641055"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">716</int>
-						<reference key="object" ref="127529838"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="598276151"/>
-						</array>
-						<reference key="parent" ref="55856611"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">717</int>
-						<reference key="object" ref="598276151"/>
-						<reference key="parent" ref="127529838"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">119</int>
-						<reference key="object" ref="366330173"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="507186717"/>
-						</array>
-						<reference key="parent" ref="150217438"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">431</int>
-						<reference key="object" ref="507186717"/>
-						<reference key="parent" ref="366330173"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">152</int>
-						<reference key="object" ref="666364138"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="450133651"/>
-						</array>
-						<reference key="parent" ref="150217438"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">433</int>
-						<reference key="object" ref="450133651"/>
-						<reference key="parent" ref="666364138"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">718</int>
-						<reference key="object" ref="967409140"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="335672329"/>
-						</array>
-						<reference key="parent" ref="150217438"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">719</int>
-						<reference key="object" ref="335672329"/>
-						<reference key="parent" ref="967409140"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">748</int>
-						<reference key="object" ref="475001756"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="32408489"/>
-						</array>
-						<reference key="parent" ref="131199459"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">749</int>
-						<reference key="object" ref="32408489"/>
-						<reference key="parent" ref="475001756"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">791</int>
-						<reference key="object" ref="533408090"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="406689511"/>
-						</array>
-						<reference key="parent" ref="432098287"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">792</int>
-						<reference key="object" ref="406689511"/>
-						<reference key="parent" ref="533408090"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">796</int>
-						<reference key="object" ref="86511413"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="562744354"/>
-						</array>
-						<reference key="parent" ref="19718304"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">797</int>
-						<reference key="object" ref="562744354"/>
-						<reference key="parent" ref="86511413"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">798</int>
-						<reference key="object" ref="367627207"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="959996177"/>
-						</array>
-						<reference key="parent" ref="19718304"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">799</int>
-						<reference key="object" ref="959996177"/>
-						<reference key="parent" ref="367627207"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">800</int>
-						<reference key="object" ref="1030426936"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="928059081"/>
-						</array>
-						<reference key="parent" ref="19718304"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">801</int>
-						<reference key="object" ref="928059081"/>
-						<reference key="parent" ref="1030426936"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">802</int>
-						<reference key="object" ref="542998689"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="550969866"/>
-						</array>
-						<reference key="parent" ref="19718304"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">803</int>
-						<reference key="object" ref="550969866"/>
-						<reference key="parent" ref="542998689"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">806</int>
-						<reference key="object" ref="1005457499"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="987151587"/>
-						</array>
-						<reference key="parent" ref="820917927"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">807</int>
-						<reference key="object" ref="987151587"/>
-						<reference key="parent" ref="1005457499"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">808</int>
-						<reference key="object" ref="449540546"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="254983759"/>
-						</array>
-						<reference key="parent" ref="820917927"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">809</int>
-						<reference key="object" ref="254983759"/>
-						<reference key="parent" ref="449540546"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">811</int>
-						<reference key="object" ref="637075528"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="20224732"/>
-						</array>
-						<reference key="parent" ref="150217438"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">812</int>
-						<reference key="object" ref="1053086435"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="943834700"/>
-						</array>
-						<reference key="parent" ref="150217438"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">813</int>
-						<reference key="object" ref="943834700"/>
-						<reference key="parent" ref="1053086435"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">814</int>
-						<reference key="object" ref="20224732"/>
-						<reference key="parent" ref="637075528"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">815</int>
-						<reference key="object" ref="1028551236"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="622607969"/>
-						</array>
-						<reference key="parent" ref="150217438"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">816</int>
-						<reference key="object" ref="779767674"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="106735145"/>
-						</array>
-						<reference key="parent" ref="150217438"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">817</int>
-						<reference key="object" ref="106735145"/>
-						<reference key="parent" ref="779767674"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">818</int>
-						<reference key="object" ref="622607969"/>
-						<reference key="parent" ref="1028551236"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">821</int>
-						<reference key="object" ref="998640248"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="875548376"/>
-						</array>
-						<reference key="parent" ref="150217438"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">822</int>
-						<reference key="object" ref="875548376"/>
-						<reference key="parent" ref="998640248"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">826</int>
-						<reference key="object" ref="962156983"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="1072147515"/>
-						</array>
-						<reference key="parent" ref="150217438"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">827</int>
-						<reference key="object" ref="1072147515"/>
-						<reference key="parent" ref="962156983"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">830</int>
-						<reference key="object" ref="506678724"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="31633568"/>
-						</array>
-						<reference key="parent" ref="57587199"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">831</int>
-						<reference key="object" ref="31633568"/>
-						<reference key="parent" ref="506678724"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">833</int>
-						<reference key="object" ref="255235135"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="438880081"/>
-						</array>
-						<reference key="parent" ref="131199459"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">834</int>
-						<reference key="object" ref="199654805"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="167413563"/>
-						</array>
-						<reference key="parent" ref="131199459"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">835</int>
-						<reference key="object" ref="167413563"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="915719007"/>
-						</array>
-						<reference key="parent" ref="199654805"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">836</int>
-						<reference key="object" ref="915719007"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="1051492125"/>
-							<reference ref="1060181807"/>
-							<reference ref="653582089"/>
-						</array>
-						<reference key="parent" ref="167413563"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">837</int>
-						<reference key="object" ref="1051492125"/>
-						<reference key="parent" ref="915719007"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">839</int>
-						<reference key="object" ref="1060181807"/>
-						<reference key="parent" ref="915719007"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">840</int>
-						<reference key="object" ref="653582089"/>
-						<reference key="parent" ref="915719007"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">842</int>
-						<reference key="object" ref="438880081"/>
-						<reference key="parent" ref="255235135"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">844</int>
-						<reference key="object" ref="858794840"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="144903932"/>
-						</array>
-						<reference key="parent" ref="131199459"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">845</int>
-						<reference key="object" ref="144903932"/>
-						<reference key="parent" ref="858794840"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">846</int>
-						<reference key="object" ref="887471351"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="939905285"/>
-						</array>
-						<reference key="parent" ref="131199459"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">847</int>
-						<reference key="object" ref="939905285"/>
-						<reference key="parent" ref="887471351"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">848</int>
-						<reference key="object" ref="241602288"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="493118706"/>
-						</array>
-						<reference key="parent" ref="131199459"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">849</int>
-						<reference key="object" ref="823414242"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="1003697772"/>
-						</array>
-						<reference key="parent" ref="131199459"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">850</int>
-						<reference key="object" ref="1003697772"/>
-						<reference key="parent" ref="823414242"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">851</int>
-						<reference key="object" ref="493118706"/>
-						<reference key="parent" ref="241602288"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">852</int>
-						<reference key="object" ref="1048498102"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="107763750"/>
-						</array>
-						<reference key="parent" ref="131199459"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">853</int>
-						<reference key="object" ref="317149642"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="242789126"/>
-						</array>
-						<reference key="parent" ref="131199459"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">854</int>
-						<reference key="object" ref="242789126"/>
-						<reference key="parent" ref="317149642"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">855</int>
-						<reference key="object" ref="107763750"/>
-						<reference key="parent" ref="1048498102"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">860</int>
-						<reference key="object" ref="220142712"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="137863314"/>
-						</array>
-						<reference key="parent" ref="820917927"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">861</int>
-						<reference key="object" ref="137863314"/>
-						<reference key="parent" ref="220142712"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">875</int>
-						<reference key="object" ref="317580382"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="661204790"/>
-						</array>
-						<reference key="parent" ref="820917927"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">876</int>
-						<reference key="object" ref="661204790"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="351537137"/>
-						</array>
-						<reference key="parent" ref="317580382"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">877</int>
-						<reference key="object" ref="351537137"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="921365143"/>
-							<reference ref="933741359"/>
-						</array>
-						<reference key="parent" ref="661204790"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">878</int>
-						<reference key="object" ref="921365143"/>
-						<reference key="parent" ref="351537137"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">879</int>
-						<reference key="object" ref="933741359"/>
-						<reference key="parent" ref="351537137"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">883</int>
-						<reference key="object" ref="195567578"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="630544053"/>
-						</array>
-						<reference key="parent" ref="715816214"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">884</int>
-						<reference key="object" ref="312647408"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="41031450"/>
-						</array>
-						<reference key="parent" ref="715816214"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">885</int>
-						<reference key="object" ref="619505271"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="228489341"/>
-						</array>
-						<reference key="parent" ref="715816214"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">886</int>
-						<reference key="object" ref="228489341"/>
-						<reference key="parent" ref="619505271"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">887</int>
-						<reference key="object" ref="41031450"/>
-						<reference key="parent" ref="312647408"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">888</int>
-						<reference key="object" ref="630544053"/>
-						<reference key="parent" ref="195567578"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">894</int>
-						<reference key="object" ref="311130897"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="707145847"/>
-						</array>
-						<reference key="parent" ref="715816214"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">895</int>
-						<reference key="object" ref="707145847"/>
-						<reference key="parent" ref="311130897"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">898</int>
-						<reference key="object" ref="237037613"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="867671735"/>
-						</array>
-						<reference key="parent" ref="820917927"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">899</int>
-						<reference key="object" ref="867671735"/>
-						<reference key="parent" ref="237037613"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">910</int>
-						<reference key="object" ref="846995571"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="694790679"/>
-						</array>
-						<reference key="parent" ref="19718304"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">911</int>
-						<reference key="object" ref="694790679"/>
-						<reference key="parent" ref="846995571"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">913</int>
-						<reference key="object" ref="479388100"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="911785969"/>
-						</array>
-						<reference key="parent" ref="402415888"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">914</int>
-						<reference key="object" ref="911785969"/>
-						<reference key="parent" ref="479388100"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">915</int>
-						<reference key="object" ref="501949360"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="329783002"/>
-						</array>
-						<reference key="parent" ref="402415888"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">916</int>
-						<reference key="object" ref="329783002"/>
-						<reference key="parent" ref="501949360"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">921</int>
-						<reference key="object" ref="299610555"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="309129550"/>
-						</array>
-						<reference key="parent" ref="820917927"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">922</int>
-						<reference key="object" ref="309129550"/>
-						<reference key="parent" ref="299610555"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">923</int>
-						<reference key="object" ref="1069702818"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="241887693"/>
-						</array>
-						<reference key="parent" ref="1053574686"/>
-						<string key="objectName">Advanced</string>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">924</int>
-						<reference key="object" ref="241887693"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="546931793"/>
-							<reference ref="592489601"/>
-							<reference ref="828279874"/>
-							<reference ref="635477378"/>
-							<reference ref="400997636"/>
-							<reference ref="645188295"/>
-							<reference ref="386977525"/>
-							<reference ref="719728854"/>
-							<reference ref="587008753"/>
-							<reference ref="364692266"/>
-							<reference ref="602004972"/>
-						</array>
-						<reference key="parent" ref="1069702818"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">951</int>
-						<reference key="object" ref="719728854"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="339217709"/>
-						</array>
-						<reference key="parent" ref="241887693"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">952</int>
-						<reference key="object" ref="645188295"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="583034087"/>
-						</array>
-						<reference key="parent" ref="241887693"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">953</int>
-						<reference key="object" ref="400997636"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="524145576"/>
-						</array>
-						<reference key="parent" ref="241887693"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">954</int>
-						<reference key="object" ref="635477378"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="110751444"/>
-						</array>
-						<reference key="parent" ref="241887693"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">955</int>
-						<reference key="object" ref="386977525"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="944772043"/>
-						</array>
-						<reference key="parent" ref="241887693"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">956</int>
-						<reference key="object" ref="944772043"/>
-						<reference key="parent" ref="386977525"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">957</int>
-						<reference key="object" ref="110751444"/>
-						<reference key="parent" ref="635477378"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">958</int>
-						<reference key="object" ref="524145576"/>
-						<reference key="parent" ref="400997636"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">959</int>
-						<reference key="object" ref="583034087"/>
-						<reference key="parent" ref="645188295"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">960</int>
-						<reference key="object" ref="339217709"/>
-						<reference key="parent" ref="719728854"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">116</int>
-						<reference key="object" ref="587008753"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="117896380"/>
-						</array>
-						<reference key="parent" ref="241887693"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">541</int>
-						<reference key="object" ref="117896380"/>
-						<reference key="parent" ref="587008753"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">141</int>
-						<reference key="object" ref="364692266"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="335421573"/>
-						</array>
-						<reference key="parent" ref="241887693"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">543</int>
-						<reference key="object" ref="335421573"/>
-						<reference key="parent" ref="364692266"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">136</int>
-						<reference key="object" ref="602004972"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="667747744"/>
-						</array>
-						<reference key="parent" ref="241887693"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">542</int>
-						<reference key="object" ref="667747744"/>
-						<reference key="parent" ref="602004972"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">184</int>
-						<reference key="object" ref="546931793"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="215407226"/>
-						</array>
-						<reference key="parent" ref="241887693"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">546</int>
-						<reference key="object" ref="215407226"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="1032320442"/>
-						</array>
-						<reference key="parent" ref="546931793"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">31</int>
-						<reference key="object" ref="1032320442"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="206515966"/>
-							<reference ref="478326210"/>
-							<reference ref="527276832"/>
-						</array>
-						<reference key="parent" ref="215407226"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">52</int>
-						<reference key="object" ref="206515966"/>
-						<reference key="parent" ref="1032320442"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">44</int>
-						<reference key="object" ref="478326210"/>
-						<reference key="parent" ref="1032320442"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">22</int>
-						<reference key="object" ref="527276832"/>
-						<reference key="parent" ref="1032320442"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">73</int>
-						<reference key="object" ref="592489601"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="905422449"/>
-						</array>
-						<reference key="parent" ref="241887693"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">538</int>
-						<reference key="object" ref="905422449"/>
-						<reference key="parent" ref="592489601"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">766</int>
-						<reference key="object" ref="828279874"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="824455942"/>
-						</array>
-						<reference key="parent" ref="241887693"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">767</int>
-						<reference key="object" ref="824455942"/>
-						<reference key="parent" ref="828279874"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">965</int>
-						<reference key="object" ref="232859697"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="90870237"/>
-						</array>
-						<reference key="parent" ref="715816214"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">966</int>
-						<reference key="object" ref="90870237"/>
-						<reference key="parent" ref="232859697"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">89</int>
-						<reference key="object" ref="50263017"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="629888737"/>
-						</array>
-						<reference key="parent" ref="432098287"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">503</int>
-						<reference key="object" ref="629888737"/>
-						<reference key="parent" ref="50263017"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">222</int>
-						<reference key="object" ref="584056154"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="1062960645"/>
-						</array>
-						<reference key="parent" ref="432098287"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">517</int>
-						<reference key="object" ref="1062960645"/>
-						<reference key="parent" ref="584056154"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">156</int>
-						<reference key="object" ref="627093559"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="861224543"/>
-						</array>
-						<reference key="parent" ref="432098287"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">509</int>
-						<reference key="object" ref="861224543"/>
-						<reference key="parent" ref="627093559"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">112</int>
-						<reference key="object" ref="883100964"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="986304381"/>
-						</array>
-						<reference key="parent" ref="432098287"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">505</int>
-						<reference key="object" ref="986304381"/>
-						<reference key="parent" ref="883100964"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">62</int>
-						<reference key="object" ref="388795386"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="629136392"/>
-						</array>
-						<reference key="parent" ref="432098287"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">499</int>
-						<reference key="object" ref="629136392"/>
-						<reference key="parent" ref="388795386"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">210</int>
-						<reference key="object" ref="1051657128"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="208523081"/>
-						</array>
-						<reference key="parent" ref="432098287"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">515</int>
-						<reference key="object" ref="208523081"/>
-						<reference key="parent" ref="1051657128"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">626</int>
-						<reference key="object" ref="697368484"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="633881091"/>
-						</array>
-						<reference key="parent" ref="432098287"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">627</int>
-						<reference key="object" ref="633881091"/>
-						<reference key="parent" ref="697368484"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">968</int>
-						<reference key="object" ref="781764471"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="970892027"/>
-						</array>
-						<reference key="parent" ref="715816214"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">969</int>
-						<reference key="object" ref="970892027"/>
-						<reference key="parent" ref="781764471"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">970</int>
-						<reference key="object" ref="16204397"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="505560439"/>
-						</array>
-						<reference key="parent" ref="715816214"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">971</int>
-						<reference key="object" ref="505560439"/>
-						<reference key="parent" ref="16204397"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">972</int>
-						<reference key="object" ref="228398657"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="919012485"/>
-						</array>
-						<reference key="parent" ref="715816214"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">973</int>
-						<reference key="object" ref="919012485"/>
-						<reference key="parent" ref="228398657"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">975</int>
-						<reference key="object" ref="813833386"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="274140887"/>
-						</array>
-						<reference key="parent" ref="208408466"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">976</int>
-						<reference key="object" ref="274140887"/>
-						<reference key="parent" ref="813833386"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">978</int>
-						<reference key="object" ref="257956724"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="154143973"/>
-						</array>
-						<reference key="parent" ref="416415920"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">979</int>
-						<reference key="object" ref="154143973"/>
-						<reference key="parent" ref="257956724"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">980</int>
-						<reference key="object" ref="667026855"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="391251816"/>
-						</array>
-						<reference key="parent" ref="416415920"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">981</int>
-						<reference key="object" ref="391251816"/>
-						<reference key="parent" ref="667026855"/>
-					</object>
-				</array>
-			</object>
-			<dictionary class="NSMutableDictionary" key="flattenedProperties">
-				<string key="-1.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="-2.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="-3.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="10.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="100.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="101.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="102.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="103.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="104.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="105.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="107.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="108.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="109.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="11.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="110.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="111.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="111.IBWindowTemplateEditedContentRect">{{228, 268}, {640, 497}}</string>
-				<string key="112.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="113.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="114.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="115.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="116.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="117.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="118.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="119.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="12.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="120.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="121.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="122.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="123.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="124.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="125.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="126.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="127.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="128.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="129.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="13.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="130.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="132.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="133.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="134.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="135.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="136.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="137.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="138.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="139.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="14.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="140.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="141.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="142.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="143.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="144.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="145.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="146.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="147.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="148.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="149.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="15.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="150.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="151.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="152.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="153.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="154.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="155.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="156.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="157.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="158.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="159.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="16.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="160.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="161.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="162.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="163.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="164.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="165.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="166.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="167.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="168.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="17.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="170.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="171.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="172.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="173.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="174.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="175.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="176.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="177.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="178.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="179.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="18.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="180.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="181.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="182.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="183.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="184.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="186.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="187.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="188.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="189.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="19.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="190.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="191.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="192.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="193.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="194.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="195.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="196.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="197.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="198.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="199.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="20.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="200.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="201.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="202.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="203.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="204.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="205.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="206.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="207.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="208.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="209.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="21.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="210.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="211.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="212.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="213.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="214.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="215.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="216.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="217.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="218.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="219.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="22.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="220.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="221.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="222.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="223.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="224.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="225.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="23.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="24.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="25.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="26.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="27.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="28.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="29.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="30.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="31.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="313.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="314.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="315.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="316.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="317.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="318.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="32.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="322.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="323.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="33.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<array class="NSMutableArray" key="33.IBUserGuides"/>
-				<string key="337.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="338.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="339.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="34.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="340.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="341.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="342.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="343.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="344.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="345.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="346.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="347.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="348.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="349.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="35.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="350.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="351.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="352.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="353.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="354.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="356.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="357.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="358.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="36.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="362.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="363.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="364.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="365.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="366.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="367.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="368.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="369.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="37.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="371.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="372.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="377.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="38.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="39.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="40.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="407.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="408.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="409.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="41.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="412.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="413.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="414.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="415.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="416.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="42.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="422.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="423.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="425.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="427.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="428.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="429.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="43.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="430.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="431.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="432.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="433.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="434.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="435.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="436.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="439.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="44.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="440.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="441.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="442.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="443.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="444.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="445.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="446.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="447.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="448.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="45.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="450.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="451.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="452.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="453.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="454.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="455.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="456.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="457.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="458.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="459.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="46.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="460.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="461.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="462.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="463.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="464.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="465.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="466.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="467.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="468.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="469.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="47.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="470.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="471.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="472.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="473.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="474.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="475.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="476.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="477.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="478.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="479.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="48.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="480.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="481.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="482.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="483.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="484.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="485.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="486.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="487.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="491.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="492.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="493.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="494.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="495.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="496.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="497.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="498.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="499.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="50.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="500.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="501.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="502.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="503.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="504.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="505.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="506.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="507.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="508.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="509.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="51.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="510.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="511.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="512.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="513.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="514.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="515.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="516.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="517.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="519.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="52.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="520.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="521.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="522.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="523.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="524.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="526.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="527.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="528.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="529.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="530.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="531.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="532.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="533.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="534.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="535.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="536.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="537.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="538.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="539.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="54.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="540.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="541.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="542.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="543.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="544.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="545.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="546.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="547.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="548.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="549.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="55.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="550.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="551.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="552.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="553.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="554.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="555.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="556.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="557.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="558.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="559.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="56.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="560.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="561.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="562.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="563.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="564.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="565.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="566.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="567.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="568.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="569.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="57.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="570.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="571.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="572.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="573.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="574.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="575.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="576.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="577.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="578.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="579.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="58.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="580.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<boolean value="YES" key="580.IBShouldRemoveOnLegacySave"/>
-				<string key="581.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<boolean value="YES" key="581.IBShouldRemoveOnLegacySave"/>
-				<string key="582.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<boolean value="YES" key="582.IBShouldRemoveOnLegacySave"/>
-				<string key="583.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<boolean value="YES" key="583.IBShouldRemoveOnLegacySave"/>
-				<string key="584.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<boolean value="YES" key="584.IBShouldRemoveOnLegacySave"/>
-				<string key="585.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<boolean value="YES" key="585.IBShouldRemoveOnLegacySave"/>
-				<string key="586.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<boolean value="YES" key="586.IBShouldRemoveOnLegacySave"/>
-				<string key="587.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<boolean value="YES" key="587.IBShouldRemoveOnLegacySave"/>
-				<string key="588.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<boolean value="YES" key="588.IBShouldRemoveOnLegacySave"/>
-				<string key="589.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<boolean value="YES" key="589.IBShouldRemoveOnLegacySave"/>
-				<string key="59.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="590.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<boolean value="YES" key="590.IBShouldRemoveOnLegacySave"/>
-				<string key="592.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="593.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="594.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="595.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="596.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="597.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="598.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="599.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="6.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="60.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="600.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="601.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="602.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="603.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="604.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="605.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="61.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="618.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="619.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="62.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="620.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="621.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="622.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="623.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="624.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="625.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="626.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="627.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="628.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="629.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="63.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="630.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="631.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="632.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="633.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="634.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="635.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="636.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="637.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="638.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="639.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="64.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="640.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="641.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="642.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="643.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="644.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="645.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="646.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="647.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="648.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="649.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="65.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="650.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="651.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="66.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="67.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="68.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="69.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="7.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="70.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<dictionary class="NSMutableDictionary" key="709.IBAttributePlaceholdersKey"/>
-				<string key="709.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="71.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="710.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="711.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="712.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="713.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="714.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="716.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="717.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="718.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="719.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="72.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="73.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="74.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="748.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="749.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="75.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="76.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="766.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="767.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="77.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="78.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="79.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="791.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="792.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="796.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="797.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="798.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="799.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="8.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="80.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="800.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="801.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="802.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="803.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="806.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="807.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="808.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="809.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="81.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="811.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="812.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="813.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="814.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="815.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="816.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="817.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="818.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="82.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="821.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="822.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="826.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="827.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="83.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="830.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="831.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="833.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="834.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="835.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="836.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="837.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="839.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="840.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="842.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="844.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="845.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="846.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="847.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="848.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="849.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="85.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="850.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="851.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="852.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="853.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="854.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="855.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="86.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="860.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="861.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="87.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="875.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="876.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="877.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="878.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="879.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="88.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="883.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="884.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="885.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="886.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="887.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="888.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="89.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="894.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="895.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="898.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="899.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="9.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="90.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="91.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="910.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="911.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="913.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="914.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="915.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="916.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="92.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="921.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="922.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="923.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="924.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="93.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="94.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="95.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="951.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="952.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="953.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="954.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="955.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="956.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="957.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="958.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="959.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="96.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="960.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="965.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="966.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="968.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="969.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="97.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="970.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="971.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="972.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="973.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="975.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="976.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="978.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="979.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="98.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="980.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="981.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="99.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-			</dictionary>
-			<dictionary class="NSMutableDictionary" key="unlocalizedProperties"/>
-			<nil key="activeLocalization"/>
-			<dictionary class="NSMutableDictionary" key="localizations"/>
-			<nil key="sourceID"/>
-			<int key="maxID">983</int>
-		</object>
-		<object class="IBClassDescriber" key="IBDocument.Classes">
-			<array class="NSMutableArray" key="referencedPartialClassDescriptions">
-				<object class="IBPartialClassDescription">
-					<string key="className">PreferencesWindow</string>
-					<string key="superclassName">UtilityWindow</string>
-					<dictionary class="NSMutableDictionary" key="actions">
-						<string key="applyBackgroundImage:">id</string>
-						<string key="applyFont:">id</string>
-						<string key="applyPreferences:">id</string>
-						<string key="applyTranparency:">id</string>
-						<string key="loadColorFromDefault:">id</string>
-						<string key="loadColorFromFile:">id</string>
-						<string key="performCancel:">id</string>
-						<string key="performOK:">id</string>
-						<string key="removeBackgroundImage:">id</string>
-						<string key="showRawPreferences:">id</string>
-					</dictionary>
-					<dictionary class="NSMutableDictionary" key="actionInfosByName">
-						<object class="IBActionInfo" key="applyBackgroundImage:">
-							<string key="name">applyBackgroundImage:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBActionInfo" key="applyFont:">
-							<string key="name">applyFont:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBActionInfo" key="applyPreferences:">
-							<string key="name">applyPreferences:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBActionInfo" key="applyTranparency:">
-							<string key="name">applyTranparency:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBActionInfo" key="loadColorFromDefault:">
-							<string key="name">loadColorFromDefault:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBActionInfo" key="loadColorFromFile:">
-							<string key="name">loadColorFromFile:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBActionInfo" key="performCancel:">
-							<string key="name">performCancel:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBActionInfo" key="performOK:">
-							<string key="name">performOK:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBActionInfo" key="removeBackgroundImage:">
-							<string key="name">removeBackgroundImage:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBActionInfo" key="showRawPreferences:">
-							<string key="name">showRawPreferences:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-					</dictionary>
-					<dictionary class="NSMutableDictionary" key="outlets">
-						<string key="autoAcceptDccChatPopUp">NSPopUpButton</string>
-						<string key="autoAcceptDccPopUp">NSPopUpButton</string>
-						<string key="autoAwayCheckBox">NSButton</string>
-						<string key="autoAwayMinutesTextField">NSTextField</string>
-						<string key="autoDialogCheckBox">NSButton</string>
-						<string key="autoOpenDccChatCheckBox">NSButton</string>
-						<string key="autoOpenDccReceiveCheckBox">NSButton</string>
-						<string key="autoOpenDccSendCheckBox">NSButton</string>
-						<string key="autoReconnectCheckBox">NSButton</string>
-						<string key="autoReconnectDelayTextField">NSTextField</string>
-						<string key="autoRejoinCheckBox">NSButton</string>
-						<string key="autoUnmarkAwayCheckBox">NSButton</string>
-						<string key="autocorrectionCheckBox">NSButton</string>
-						<string key="awayMaxSizeTextField">NSTextField</string>
-						<string key="awayMessageTextField">NSTextField</string>
-						<string key="awayTrackCheckBox">NSButton</string>
-						<string key="backgroundImageTextField">NSTextField</string>
-						<string key="beepOnChannelCheckBox">NSButton</string>
-						<string key="beepOnHighlightedCheckBox">NSButton</string>
-						<string key="beepOnPrivateCheckBox">NSButton</string>
-						<string key="bindAddressTextField">NSTextField</string>
-						<string key="bounceCountinuouslyCheckBox">NSButton</string>
-						<string key="categoryOutlineView">NSOutlineView</string>
-						<string key="channelLinkCommandTextField">NSTextField</string>
-						<string key="coloredNicksCheckBox">NSButton</string>
-						<string key="colorsTabViewItem">NSTabViewItem</string>
-						<string key="completedDownloadsDirectoryTextField">NSTextField</string>
-						<string key="contentBox">NSBox</string>
-						<string key="dccAddressTextField">NSTextField</string>
-						<string key="dccFirstSendPortTextField">NSTextField</string>
-						<string key="dccLastSendPortTextField">NSTextField</string>
-						<string key="defaultCharsetTextField">NSTextField</string>
-						<string key="displayPreviousScrollbackCheckBox">NSButton</string>
-						<string key="doubleClickCommandTextField">NSTextField</string>
-						<string key="downloadSpaceToUnderscoreCheckBox">NSButton</string>
-						<string key="downloadWithNickCheckBox">NSButton</string>
-						<string key="downloadsDirectoryTextField">NSTextField</string>
-						<string key="enableLoggingCheckBox">NSButton</string>
-						<string key="extraHighlightWordsTextField">NSTextField</string>
-						<string key="grammerCheckingCheckBox">NSButton</string>
-						<string key="hideJoinPartCheckBox">NSButton</string>
-						<string key="hideTabCloseButtonsCheckBox">NSButton</string>
-						<string key="hideUserlistCheckBox">NSButton</string>
-						<string key="identdCheckBox">NSButton</string>
-						<string key="indentNicksCheckBox">NSButton</string>
-						<string key="inputBoxUseTextBoxFontCheckBox">NSButton</string>
-						<string key="interpretPercentAsciiCheckBox">NSButton</string>
-						<string key="interpretPercentColorCheckBox">NSButton</string>
-						<string key="ipFromServerCheckBox">NSButton</string>
-						<string key="lineHeightTextField">NSTextField</string>
-						<string key="logFilenameMaskTextField">NSTextField</string>
-						<string key="maxLinesTextField">NSTextField</string>
-						<string key="neverGiveUpReconnectionCheckBox">NSButton</string>
-						<string key="newTabsToFrontCheckBox">NSButton</string>
-						<string key="nickCompletionSortPopUp">NSPopUpButton</string>
-						<string key="nickHighlightWordsTextField">NSTextField</string>
-						<string key="nickLinkCommandTextField">NSTextField</string>
-						<string key="noHighlightWordsTextField">NSTextField</string>
-						<string key="openChannelsInPopUp">NSPopUpButton</string>
-						<string key="openDialogsInPopUp">NSPopUpButton</string>
-						<string key="openUtilitiesInPopUp">NSPopUpButton</string>
-						<string key="partMessageTextField">NSTextField</string>
-						<string key="partOnSleepCheckBox">NSButton</string>
-						<string key="proxyAuthenicationCheckBox">NSButton</string>
-						<string key="proxyHostTextField">NSTextField</string>
-						<string key="proxyPasswordTextField">NSTextField</string>
-						<string key="proxyPortTextField">NSTextField</string>
-						<string key="proxyTypePopUp">NSPopUpButton</string>
-						<string key="proxyUsePopup">NSPopUpButton</string>
-						<string key="proxyUsernameTextField">NSTextField</string>
-						<string key="quitMessageTextField">NSTextField</string>
-						<string key="rawModesCheckBox">NSButton</string>
-						<string key="scrollbackStripColorCheckBox">NSButton</string>
-						<string key="scrollingCompletionCheckBox">NSButton</string>
-						<string key="shortenTabLabelLengthTextField">NSTextField</string>
-						<string key="showAwayMessageCheckBox">NSButton</string>
-						<string key="showAwayOnceCheckBox">NSButton</string>
-						<string key="showChannelModeButtonsCheckBox">NSButton</string>
-						<string key="showHostnameCheckBox">NSButton</string>
-						<string key="showSeparatorCheckBox">NSButton</string>
-						<string key="showUserlistButtonsCheckBox">NSButton</string>
-						<string key="sleepMessageTextField">NSTextField</string>
-						<string key="smallerTextTabCheckBox">NSButton</string>
-						<string key="soundsTableView">NSTableView</string>
-						<string key="spellCheckingCheckBox">NSButton</string>
-						<string key="stripMircColorCheckBox">NSButton</string>
-						<string key="suffixCompletionCheckBox">NSButton</string>
-						<string key="suffixCompletionTextField">NSTextField</string>
-						<string key="switcherTypePopUp">NSPopUpButton</string>
-						<string key="tabCompletionCheckBox">NSButton</string>
-						<string key="tabLeftRecorderCell">SRRecorderCell</string>
-						<string key="tabPositionPopUp">NSPopUpButton</string>
-						<string key="tabRightRecorderCell">SRRecorderCell</string>
-						<string key="tabView">NSTabView</string>
-						<string key="textBoxFontTextField">NSTextField</string>
-						<string key="timeStampCheckBox">NSButton</string>
-						<string key="timeStampFormatTextField">NSTextField</string>
-						<string key="timestampInLogsFormatTextField">NSTextField</string>
-						<string key="timestampsInLogsCheckBox">NSButton</string>
-						<string key="transparentCheckBox">NSButton</string>
-						<string key="transparentSlider">NSSlider</string>
-						<string key="urlLinkCommandTextField">NSTextField</string>
-						<string key="useNoticesTabCheckBox">NSButton</string>
-						<string key="useServerTabCheckBox">NSButton</string>
-						<string key="userlistSortPopUp">NSPopUpButton</string>
-						<string key="userlistUseTextBoxFontCheckBox">NSButton</string>
-						<string key="whoisOnNotifyCheckBox">NSButton</string>
-					</dictionary>
-					<dictionary class="NSMutableDictionary" key="toOneOutletInfosByName">
-						<object class="IBToOneOutletInfo" key="autoAcceptDccChatPopUp">
-							<string key="name">autoAcceptDccChatPopUp</string>
-							<string key="candidateClassName">NSPopUpButton</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="autoAcceptDccPopUp">
-							<string key="name">autoAcceptDccPopUp</string>
-							<string key="candidateClassName">NSPopUpButton</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="autoAwayCheckBox">
-							<string key="name">autoAwayCheckBox</string>
-							<string key="candidateClassName">NSButton</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="autoAwayMinutesTextField">
-							<string key="name">autoAwayMinutesTextField</string>
-							<string key="candidateClassName">NSTextField</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="autoDialogCheckBox">
-							<string key="name">autoDialogCheckBox</string>
-							<string key="candidateClassName">NSButton</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="autoOpenDccChatCheckBox">
-							<string key="name">autoOpenDccChatCheckBox</string>
-							<string key="candidateClassName">NSButton</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="autoOpenDccReceiveCheckBox">
-							<string key="name">autoOpenDccReceiveCheckBox</string>
-							<string key="candidateClassName">NSButton</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="autoOpenDccSendCheckBox">
-							<string key="name">autoOpenDccSendCheckBox</string>
-							<string key="candidateClassName">NSButton</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="autoReconnectCheckBox">
-							<string key="name">autoReconnectCheckBox</string>
-							<string key="candidateClassName">NSButton</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="autoReconnectDelayTextField">
-							<string key="name">autoReconnectDelayTextField</string>
-							<string key="candidateClassName">NSTextField</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="autoRejoinCheckBox">
-							<string key="name">autoRejoinCheckBox</string>
-							<string key="candidateClassName">NSButton</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="autoUnmarkAwayCheckBox">
-							<string key="name">autoUnmarkAwayCheckBox</string>
-							<string key="candidateClassName">NSButton</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="autocorrectionCheckBox">
-							<string key="name">autocorrectionCheckBox</string>
-							<string key="candidateClassName">NSButton</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="awayMaxSizeTextField">
-							<string key="name">awayMaxSizeTextField</string>
-							<string key="candidateClassName">NSTextField</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="awayMessageTextField">
-							<string key="name">awayMessageTextField</string>
-							<string key="candidateClassName">NSTextField</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="awayTrackCheckBox">
-							<string key="name">awayTrackCheckBox</string>
-							<string key="candidateClassName">NSButton</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="backgroundImageTextField">
-							<string key="name">backgroundImageTextField</string>
-							<string key="candidateClassName">NSTextField</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="beepOnChannelCheckBox">
-							<string key="name">beepOnChannelCheckBox</string>
-							<string key="candidateClassName">NSButton</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="beepOnHighlightedCheckBox">
-							<string key="name">beepOnHighlightedCheckBox</string>
-							<string key="candidateClassName">NSButton</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="beepOnPrivateCheckBox">
-							<string key="name">beepOnPrivateCheckBox</string>
-							<string key="candidateClassName">NSButton</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="bindAddressTextField">
-							<string key="name">bindAddressTextField</string>
-							<string key="candidateClassName">NSTextField</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="bounceCountinuouslyCheckBox">
-							<string key="name">bounceCountinuouslyCheckBox</string>
-							<string key="candidateClassName">NSButton</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="categoryOutlineView">
-							<string key="name">categoryOutlineView</string>
-							<string key="candidateClassName">NSOutlineView</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="channelLinkCommandTextField">
-							<string key="name">channelLinkCommandTextField</string>
-							<string key="candidateClassName">NSTextField</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="coloredNicksCheckBox">
-							<string key="name">coloredNicksCheckBox</string>
-							<string key="candidateClassName">NSButton</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="colorsTabViewItem">
-							<string key="name">colorsTabViewItem</string>
-							<string key="candidateClassName">NSTabViewItem</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="completedDownloadsDirectoryTextField">
-							<string key="name">completedDownloadsDirectoryTextField</string>
-							<string key="candidateClassName">NSTextField</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="contentBox">
-							<string key="name">contentBox</string>
-							<string key="candidateClassName">NSBox</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="dccAddressTextField">
-							<string key="name">dccAddressTextField</string>
-							<string key="candidateClassName">NSTextField</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="dccFirstSendPortTextField">
-							<string key="name">dccFirstSendPortTextField</string>
-							<string key="candidateClassName">NSTextField</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="dccLastSendPortTextField">
-							<string key="name">dccLastSendPortTextField</string>
-							<string key="candidateClassName">NSTextField</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="defaultCharsetTextField">
-							<string key="name">defaultCharsetTextField</string>
-							<string key="candidateClassName">NSTextField</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="displayPreviousScrollbackCheckBox">
-							<string key="name">displayPreviousScrollbackCheckBox</string>
-							<string key="candidateClassName">NSButton</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="doubleClickCommandTextField">
-							<string key="name">doubleClickCommandTextField</string>
-							<string key="candidateClassName">NSTextField</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="downloadSpaceToUnderscoreCheckBox">
-							<string key="name">downloadSpaceToUnderscoreCheckBox</string>
-							<string key="candidateClassName">NSButton</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="downloadWithNickCheckBox">
-							<string key="name">downloadWithNickCheckBox</string>
-							<string key="candidateClassName">NSButton</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="downloadsDirectoryTextField">
-							<string key="name">downloadsDirectoryTextField</string>
-							<string key="candidateClassName">NSTextField</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="enableLoggingCheckBox">
-							<string key="name">enableLoggingCheckBox</string>
-							<string key="candidateClassName">NSButton</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="extraHighlightWordsTextField">
-							<string key="name">extraHighlightWordsTextField</string>
-							<string key="candidateClassName">NSTextField</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="grammerCheckingCheckBox">
-							<string key="name">grammerCheckingCheckBox</string>
-							<string key="candidateClassName">NSButton</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="hideJoinPartCheckBox">
-							<string key="name">hideJoinPartCheckBox</string>
-							<string key="candidateClassName">NSButton</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="hideTabCloseButtonsCheckBox">
-							<string key="name">hideTabCloseButtonsCheckBox</string>
-							<string key="candidateClassName">NSButton</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="hideUserlistCheckBox">
-							<string key="name">hideUserlistCheckBox</string>
-							<string key="candidateClassName">NSButton</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="identdCheckBox">
-							<string key="name">identdCheckBox</string>
-							<string key="candidateClassName">NSButton</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="indentNicksCheckBox">
-							<string key="name">indentNicksCheckBox</string>
-							<string key="candidateClassName">NSButton</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="inputBoxUseTextBoxFontCheckBox">
-							<string key="name">inputBoxUseTextBoxFontCheckBox</string>
-							<string key="candidateClassName">NSButton</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="interpretPercentAsciiCheckBox">
-							<string key="name">interpretPercentAsciiCheckBox</string>
-							<string key="candidateClassName">NSButton</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="interpretPercentColorCheckBox">
-							<string key="name">interpretPercentColorCheckBox</string>
-							<string key="candidateClassName">NSButton</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="ipFromServerCheckBox">
-							<string key="name">ipFromServerCheckBox</string>
-							<string key="candidateClassName">NSButton</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="lineHeightTextField">
-							<string key="name">lineHeightTextField</string>
-							<string key="candidateClassName">NSTextField</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="logFilenameMaskTextField">
-							<string key="name">logFilenameMaskTextField</string>
-							<string key="candidateClassName">NSTextField</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="maxLinesTextField">
-							<string key="name">maxLinesTextField</string>
-							<string key="candidateClassName">NSTextField</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="neverGiveUpReconnectionCheckBox">
-							<string key="name">neverGiveUpReconnectionCheckBox</string>
-							<string key="candidateClassName">NSButton</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="newTabsToFrontCheckBox">
-							<string key="name">newTabsToFrontCheckBox</string>
-							<string key="candidateClassName">NSButton</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="nickCompletionSortPopUp">
-							<string key="name">nickCompletionSortPopUp</string>
-							<string key="candidateClassName">NSPopUpButton</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="nickHighlightWordsTextField">
-							<string key="name">nickHighlightWordsTextField</string>
-							<string key="candidateClassName">NSTextField</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="nickLinkCommandTextField">
-							<string key="name">nickLinkCommandTextField</string>
-							<string key="candidateClassName">NSTextField</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="noHighlightWordsTextField">
-							<string key="name">noHighlightWordsTextField</string>
-							<string key="candidateClassName">NSTextField</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="openChannelsInPopUp">
-							<string key="name">openChannelsInPopUp</string>
-							<string key="candidateClassName">NSPopUpButton</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="openDialogsInPopUp">
-							<string key="name">openDialogsInPopUp</string>
-							<string key="candidateClassName">NSPopUpButton</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="openUtilitiesInPopUp">
-							<string key="name">openUtilitiesInPopUp</string>
-							<string key="candidateClassName">NSPopUpButton</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="partMessageTextField">
-							<string key="name">partMessageTextField</string>
-							<string key="candidateClassName">NSTextField</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="partOnSleepCheckBox">
-							<string key="name">partOnSleepCheckBox</string>
-							<string key="candidateClassName">NSButton</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="proxyAuthenicationCheckBox">
-							<string key="name">proxyAuthenicationCheckBox</string>
-							<string key="candidateClassName">NSButton</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="proxyHostTextField">
-							<string key="name">proxyHostTextField</string>
-							<string key="candidateClassName">NSTextField</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="proxyPasswordTextField">
-							<string key="name">proxyPasswordTextField</string>
-							<string key="candidateClassName">NSTextField</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="proxyPortTextField">
-							<string key="name">proxyPortTextField</string>
-							<string key="candidateClassName">NSTextField</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="proxyTypePopUp">
-							<string key="name">proxyTypePopUp</string>
-							<string key="candidateClassName">NSPopUpButton</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="proxyUsePopup">
-							<string key="name">proxyUsePopup</string>
-							<string key="candidateClassName">NSPopUpButton</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="proxyUsernameTextField">
-							<string key="name">proxyUsernameTextField</string>
-							<string key="candidateClassName">NSTextField</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="quitMessageTextField">
-							<string key="name">quitMessageTextField</string>
-							<string key="candidateClassName">NSTextField</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="rawModesCheckBox">
-							<string key="name">rawModesCheckBox</string>
-							<string key="candidateClassName">NSButton</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="scrollbackStripColorCheckBox">
-							<string key="name">scrollbackStripColorCheckBox</string>
-							<string key="candidateClassName">NSButton</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="scrollingCompletionCheckBox">
-							<string key="name">scrollingCompletionCheckBox</string>
-							<string key="candidateClassName">NSButton</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="shortenTabLabelLengthTextField">
-							<string key="name">shortenTabLabelLengthTextField</string>
-							<string key="candidateClassName">NSTextField</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="showAwayMessageCheckBox">
-							<string key="name">showAwayMessageCheckBox</string>
-							<string key="candidateClassName">NSButton</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="showAwayOnceCheckBox">
-							<string key="name">showAwayOnceCheckBox</string>
-							<string key="candidateClassName">NSButton</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="showChannelModeButtonsCheckBox">
-							<string key="name">showChannelModeButtonsCheckBox</string>
-							<string key="candidateClassName">NSButton</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="showHostnameCheckBox">
-							<string key="name">showHostnameCheckBox</string>
-							<string key="candidateClassName">NSButton</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="showSeparatorCheckBox">
-							<string key="name">showSeparatorCheckBox</string>
-							<string key="candidateClassName">NSButton</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="showUserlistButtonsCheckBox">
-							<string key="name">showUserlistButtonsCheckBox</string>
-							<string key="candidateClassName">NSButton</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="sleepMessageTextField">
-							<string key="name">sleepMessageTextField</string>
-							<string key="candidateClassName">NSTextField</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="smallerTextTabCheckBox">
-							<string key="name">smallerTextTabCheckBox</string>
-							<string key="candidateClassName">NSButton</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="soundsTableView">
-							<string key="name">soundsTableView</string>
-							<string key="candidateClassName">NSTableView</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="spellCheckingCheckBox">
-							<string key="name">spellCheckingCheckBox</string>
-							<string key="candidateClassName">NSButton</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="stripMircColorCheckBox">
-							<string key="name">stripMircColorCheckBox</string>
-							<string key="candidateClassName">NSButton</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="suffixCompletionCheckBox">
-							<string key="name">suffixCompletionCheckBox</string>
-							<string key="candidateClassName">NSButton</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="suffixCompletionTextField">
-							<string key="name">suffixCompletionTextField</string>
-							<string key="candidateClassName">NSTextField</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="switcherTypePopUp">
-							<string key="name">switcherTypePopUp</string>
-							<string key="candidateClassName">NSPopUpButton</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="tabCompletionCheckBox">
-							<string key="name">tabCompletionCheckBox</string>
-							<string key="candidateClassName">NSButton</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="tabLeftRecorderCell">
-							<string key="name">tabLeftRecorderCell</string>
-							<string key="candidateClassName">SRRecorderCell</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="tabPositionPopUp">
-							<string key="name">tabPositionPopUp</string>
-							<string key="candidateClassName">NSPopUpButton</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="tabRightRecorderCell">
-							<string key="name">tabRightRecorderCell</string>
-							<string key="candidateClassName">SRRecorderCell</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="tabView">
-							<string key="name">tabView</string>
-							<string key="candidateClassName">NSTabView</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="textBoxFontTextField">
-							<string key="name">textBoxFontTextField</string>
-							<string key="candidateClassName">NSTextField</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="timeStampCheckBox">
-							<string key="name">timeStampCheckBox</string>
-							<string key="candidateClassName">NSButton</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="timeStampFormatTextField">
-							<string key="name">timeStampFormatTextField</string>
-							<string key="candidateClassName">NSTextField</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="timestampInLogsFormatTextField">
-							<string key="name">timestampInLogsFormatTextField</string>
-							<string key="candidateClassName">NSTextField</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="timestampsInLogsCheckBox">
-							<string key="name">timestampsInLogsCheckBox</string>
-							<string key="candidateClassName">NSButton</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="transparentCheckBox">
-							<string key="name">transparentCheckBox</string>
-							<string key="candidateClassName">NSButton</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="transparentSlider">
-							<string key="name">transparentSlider</string>
-							<string key="candidateClassName">NSSlider</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="urlLinkCommandTextField">
-							<string key="name">urlLinkCommandTextField</string>
-							<string key="candidateClassName">NSTextField</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="useNoticesTabCheckBox">
-							<string key="name">useNoticesTabCheckBox</string>
-							<string key="candidateClassName">NSButton</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="useServerTabCheckBox">
-							<string key="name">useServerTabCheckBox</string>
-							<string key="candidateClassName">NSButton</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="userlistSortPopUp">
-							<string key="name">userlistSortPopUp</string>
-							<string key="candidateClassName">NSPopUpButton</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="userlistUseTextBoxFontCheckBox">
-							<string key="name">userlistUseTextBoxFontCheckBox</string>
-							<string key="candidateClassName">NSButton</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="whoisOnNotifyCheckBox">
-							<string key="name">whoisOnNotifyCheckBox</string>
-							<string key="candidateClassName">NSButton</string>
-						</object>
-					</dictionary>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBProjectSource</string>
-						<string key="minorKey">./Classes/PreferencesWindow.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">UtilityWindow</string>
-					<string key="superclassName">NSWindow</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBProjectSource</string>
-						<string key="minorKey">./Classes/UtilityWindow.h</string>
-					</object>
-				</object>
-			</array>
-		</object>
-		<int key="IBDocument.localizationMode">0</int>
-		<string key="IBDocument.TargetRuntimeIdentifier">IBCocoaFramework</string>
-		<object class="NSMutableDictionary" key="IBDocument.PluginDeclaredDependencies">
-			<string key="NS.key.0">com.apple.InterfaceBuilder.CocoaPlugin.macosx</string>
-			<real value="1070" key="NS.object.0"/>
-		</object>
-		<object class="NSMutableDictionary" key="IBDocument.PluginDeclaredDevelopmentDependencies">
-			<string key="NS.key.0">com.apple.InterfaceBuilder.CocoaPlugin.InterfaceBuilder3</string>
-			<real value="4400" key="NS.object.0"/>
-		</object>
-		<bool key="IBDocument.PluginDeclaredDependenciesTrackSystemTargetVersion">YES</bool>
-		<int key="IBDocument.defaultPropertyAccessControl">3</int>
-		<dictionary class="NSMutableDictionary" key="IBDocument.LastKnownImageSizes">
-			<string key="NSMenuCheckmark">{11, 11}</string>
-			<string key="NSMenuMixedState">{10, 3}</string>
-			<string key="NSStopProgressTemplate">{11, 11}</string>
-			<string key="NSSwitch">{15, 15}</string>
-		</dictionary>
-	</data>
-</archive>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="4514" systemVersion="13A2093" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none">
+    <dependencies>
+        <deployment version="1070" defaultVersion="1060" identifier="macosx"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="4514"/>
+    </dependencies>
+    <objects>
+        <customObject id="-2" userLabel="File's Owner" customClass="NSWindowController">
+            <connections>
+                <outlet property="window" destination="111" id="905"/>
+            </connections>
+        </customObject>
+        <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
+        <customObject id="-3" userLabel="Application"/>
+        <window title="XChat: Preferences" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" wantsToBeColor="NO" visibleAtLaunch="NO" animationBehavior="default" id="111" customClass="PreferencesWindow">
+            <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES"/>
+            <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
+            <rect key="contentRect" x="466" y="125" width="640" height="497"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1920" height="1058"/>
+            <value key="minSize" type="size" width="640" height="497"/>
+            <value key="maxSize" type="size" width="640" height="497"/>
+            <view key="contentView" id="81">
+                <rect key="frame" x="0.0" y="0.0" width="640" height="497"/>
+                <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                <subviews>
+                    <button verticalHuggingPriority="750" id="107">
+                        <rect key="frame" x="542" y="12" width="84" height="32"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxY="YES"/>
+                        <buttonCell key="cell" type="push" title="OK" bezelStyle="rounded" alignment="center" borderStyle="border" inset="2" id="578">
+                            <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                            <font key="font" metaFont="system"/>
+                            <string key="keyEquivalent" base64-UTF8="YES">
+DQ
+</string>
+                        </buttonCell>
+                        <connections>
+                            <action selector="performOK:" target="111" id="783"/>
+                        </connections>
+                    </button>
+                    <button verticalHuggingPriority="750" id="198">
+                        <rect key="frame" x="458" y="12" width="84" height="32"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxY="YES"/>
+                        <buttonCell key="cell" type="push" title="Cancel" bezelStyle="rounded" alignment="center" borderStyle="border" inset="2" id="579">
+                            <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                            <font key="font" metaFont="system"/>
+                            <string key="keyEquivalent" base64-UTF8="YES">
+Gw
+</string>
+                        </buttonCell>
+                        <connections>
+                            <action selector="performCancel:" target="111" id="784"/>
+                        </connections>
+                    </button>
+                    <button verticalHuggingPriority="750" id="55">
+                        <rect key="frame" x="374" y="12" width="84" height="32"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxY="YES"/>
+                        <buttonCell key="cell" type="push" title="Apply" bezelStyle="rounded" alignment="center" borderStyle="border" inset="2" id="576">
+                            <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                            <font key="font" metaFont="system"/>
+                        </buttonCell>
+                        <connections>
+                            <action selector="applyPreferences:" target="111" id="781"/>
+                        </connections>
+                    </button>
+                    <scrollView horizontalLineScroll="19" horizontalPageScroll="10" verticalLineScroll="19" verticalPageScroll="10" hasHorizontalScroller="NO" usesPredominantAxisScrolling="NO" id="56">
+                        <rect key="frame" x="20" y="60" width="138" height="417"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" heightSizable="YES"/>
+                        <clipView key="contentView" id="FC5-Sd-alR">
+                            <rect key="frame" x="1" y="1" width="125" height="415"/>
+                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                            <subviews>
+                                <outlineView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnReordering="NO" columnResizing="NO" multipleSelection="NO" emptySelection="NO" autosaveColumns="NO" indentationPerLevel="16" autoresizesOutlineColumn="YES" outlineTableColumn="41" id="24">
+                                    <rect key="frame" x="0.0" y="0.0" width="125" height="415"/>
+                                    <autoresizingMask key="autoresizingMask"/>
+                                    <size key="intercellSpacing" width="3" height="2"/>
+                                    <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                    <color key="gridColor" name="gridColor" catalog="System" colorSpace="catalog"/>
+                                    <tableColumns>
+                                        <tableColumn editable="NO" width="121.95999908447266" minWidth="16" maxWidth="1000" id="41">
+                                            <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left" title="Categories">
+                                                <font key="font" metaFont="smallSystem"/>
+                                                <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
+                                            </tableHeaderCell>
+                                            <textFieldCell key="dataCell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" alignment="left" drawsBackground="YES" id="585">
+                                                <font key="font" metaFont="cellTitle"/>
+                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                            </textFieldCell>
+                                        </tableColumn>
+                                    </tableColumns>
+                                    <connections>
+                                        <outlet property="dataSource" destination="111" id="706"/>
+                                        <outlet property="delegate" destination="111" id="788"/>
+                                    </connections>
+                                </outlineView>
+                            </subviews>
+                            <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
+                        </clipView>
+                        <scroller key="horizontalScroller" hidden="YES" verticalHuggingPriority="750" doubleValue="0.024" controlSize="small" horizontal="YES" id="590">
+                            <rect key="frame" x="-100" y="-100" width="125" height="11"/>
+                            <autoresizingMask key="autoresizingMask"/>
+                        </scroller>
+                        <scroller key="verticalScroller" verticalHuggingPriority="750" controlSize="small" horizontal="NO" id="589">
+                            <rect key="frame" x="126" y="1" width="11" height="415"/>
+                            <autoresizingMask key="autoresizingMask"/>
+                        </scroller>
+                    </scrollView>
+                    <box title="Text box" id="48">
+                        <rect key="frame" x="162" y="56" width="458" height="428"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <view key="contentView">
+                            <rect key="frame" x="2" y="2" width="454" height="408"/>
+                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                            <subviews>
+                                <tabView drawsBackground="NO" controlSize="small" type="noTabsNoBorder" id="65">
+                                    <rect key="frame" x="4" y="2" width="449" height="406"/>
+                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                    <tabViewItems>
+                                        <tabViewItem identifier="" id="87" userLabel="Text box">
+                                            <view key="view" id="190">
+                                                <rect key="frame" x="0.0" y="0.0" width="449" height="406"/>
+                                                <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                                <subviews>
+                                                    <textField verticalHuggingPriority="750" id="145">
+                                                        <rect key="frame" x="161" y="354" width="179" height="19"/>
+                                                        <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
+                                                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" alignment="left" drawsBackground="YES" id="508">
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                            <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                    <textField verticalHuggingPriority="750" id="970">
+                                                        <rect key="frame" x="161" y="330" width="50" height="19"/>
+                                                        <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
+                                                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" alignment="left" drawsBackground="YES" id="971">
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                            <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                    <textField verticalHuggingPriority="750" id="72">
+                                                        <rect key="frame" x="32" y="356" width="124" height="14"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="right" title="Font:" id="500">
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                    <textField verticalHuggingPriority="750" id="968">
+                                                        <rect key="frame" x="32" y="329" width="124" height="17"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="right" title="Line height:" id="969">
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                    <textField verticalHuggingPriority="750" id="972">
+                                                        <rect key="frame" x="209" y="331" width="124" height="17"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="left" title="%" id="973">
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                    <textField verticalHuggingPriority="750" id="105">
+                                                        <rect key="frame" x="161" y="89" width="220" height="19"/>
+                                                        <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
+                                                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" alignment="left" drawsBackground="YES" id="504">
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                            <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                    <textField verticalHuggingPriority="750" id="133">
+                                                        <rect key="frame" x="20" y="92" width="136" height="14"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="right" title="Time stamp format:" id="506">
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                    <button verticalHuggingPriority="750" id="18">
+                                                        <rect key="frame" x="343" y="348" width="91" height="28"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMinY="YES"/>
+                                                        <buttonCell key="cell" type="push" title="Browse..." bezelStyle="rounded" alignment="center" controlSize="small" borderStyle="border" inset="2" id="497">
+                                                            <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                        </buttonCell>
+                                                        <connections>
+                                                            <action selector="applyFont:" target="111" id="780"/>
+                                                        </connections>
+                                                    </button>
+                                                    <textField verticalHuggingPriority="750" id="883">
+                                                        <rect key="frame" x="161" y="304" width="159" height="19"/>
+                                                        <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
+                                                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" alignment="left" placeholderString="(No Image)" drawsBackground="YES" id="888">
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                            <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                    <textField verticalHuggingPriority="750" id="884">
+                                                        <rect key="frame" x="32" y="303" width="124" height="17"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="right" title="Background image:" id="887">
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                    <button verticalHuggingPriority="750" id="885">
+                                                        <rect key="frame" x="343" y="298" width="91" height="28"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMinY="YES"/>
+                                                        <buttonCell key="cell" type="push" title="Browse..." bezelStyle="rounded" alignment="center" controlSize="small" borderStyle="border" inset="2" id="886">
+                                                            <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                        </buttonCell>
+                                                        <connections>
+                                                            <action selector="applyBackgroundImage:" target="111" id="891"/>
+                                                        </connections>
+                                                    </button>
+                                                    <button verticalHuggingPriority="750" id="894">
+                                                        <rect key="frame" x="320" y="303" width="21" height="21"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMinY="YES"/>
+                                                        <buttonCell key="cell" type="smallSquare" bezelStyle="smallSquare" image="NSStopProgressTemplate" imagePosition="overlaps" alignment="center" controlSize="small" borderStyle="border" inset="2" id="895">
+                                                            <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                        </buttonCell>
+                                                        <connections>
+                                                            <action selector="removeBackgroundImage:" target="111" id="897"/>
+                                                        </connections>
+                                                    </button>
+                                                    <button id="965">
+                                                        <rect key="frame" x="231" y="279" width="200" height="19"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <buttonCell key="cell" type="check" title="Strip scrollback color" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" inset="2" id="966">
+                                                            <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                        </buttonCell>
+                                                    </button>
+                                                    <button id="163">
+                                                        <rect key="frame" x="29" y="232" width="198" height="19"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <buttonCell key="cell" type="check" title="Show separator" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" inset="2" id="510">
+                                                            <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                        </buttonCell>
+                                                    </button>
+                                                    <button id="74">
+                                                        <rect key="frame" x="231" y="232" width="200" height="19"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <buttonCell key="cell" type="check" title="Strip mIRC color" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" inset="2" id="501">
+                                                            <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                        </buttonCell>
+                                                    </button>
+                                                    <button id="83">
+                                                        <rect key="frame" x="29" y="114" width="231" height="19"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <buttonCell key="cell" type="check" title="Enable time stamps" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" inset="2" id="502">
+                                                            <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                        </buttonCell>
+                                                    </button>
+                                                    <button id="167">
+                                                        <rect key="frame" x="231" y="252" width="200" height="19"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <buttonCell key="cell" type="check" title="Indent nick names" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" inset="2" id="511">
+                                                            <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                        </buttonCell>
+                                                    </button>
+                                                    <button id="137">
+                                                        <rect key="frame" x="29" y="252" width="198" height="19"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <buttonCell key="cell" type="check" title="Colored nick names" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" inset="2" id="507">
+                                                            <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                        </buttonCell>
+                                                    </button>
+                                                    <textField verticalHuggingPriority="750" id="213">
+                                                        <rect key="frame" x="31" y="281" width="125" height="14"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="right" title="Scrollback lines:" id="516">
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                    <textField verticalHuggingPriority="750" id="205">
+                                                        <rect key="frame" x="161" y="279" width="50" height="19"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" alignment="left" drawsBackground="YES" id="514">
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                            <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                    <slider verticalHuggingPriority="750" id="194">
+                                                        <rect key="frame" x="160" y="161" width="221" height="17"/>
+                                                        <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
+                                                        <sliderCell key="cell" controlSize="small" continuous="YES" alignment="left" maxValue="255" doubleValue="201.875" tickMarkPosition="below" numberOfTickMarks="25" allowsTickMarkValuesOnly="YES" sliderType="linear" id="513">
+                                                            <font key="font" size="12" name="Helvetica"/>
+                                                        </sliderCell>
+                                                        <connections>
+                                                            <action selector="applyTranparency:" target="111" id="785"/>
+                                                        </connections>
+                                                    </slider>
+                                                    <textField verticalHuggingPriority="750" id="180">
+                                                        <rect key="frame" x="17" y="164" width="139" height="14"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="right" title="Transparency:" id="512">
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                    <button id="57">
+                                                        <rect key="frame" x="29" y="184" width="200" height="19"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <buttonCell key="cell" type="check" title="Transparent Windows" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" inset="2" id="498">
+                                                            <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                        </buttonCell>
+                                                        <connections>
+                                                            <action selector="applyTranparency:" target="111" id="786"/>
+                                                        </connections>
+                                                    </button>
+                                                    <textField verticalHuggingPriority="750" id="618">
+                                                        <rect key="frame" x="17" y="139" width="415" height="17"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Time Stamps" id="619">
+                                                            <font key="font" metaFont="systemBold"/>
+                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                    <stepper hidden="YES" horizontalHuggingPriority="750" verticalHuggingPriority="750" id="620">
+                                                        <rect key="frame" x="209" y="273" width="19" height="27"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <stepperCell key="cell" continuous="YES" alignment="left" maxValue="100" id="621"/>
+                                                    </stepper>
+                                                    <textField verticalHuggingPriority="750" id="622">
+                                                        <rect key="frame" x="17" y="381" width="415" height="17"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Text Box Appearance" id="623">
+                                                            <font key="font" metaFont="systemBold"/>
+                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                    <textField verticalHuggingPriority="750" id="624">
+                                                        <rect key="frame" x="17" y="209" width="415" height="17"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Transparency Settings" id="625">
+                                                            <font key="font" metaFont="systemBold"/>
+                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                </subviews>
+                                            </view>
+                                        </tabViewItem>
+                                        <tabViewItem identifier="" id="218" userLabel="Input box">
+                                            <view key="view" id="187">
+                                                <rect key="frame" x="0.0" y="0.0" width="449" height="406"/>
+                                                <autoresizingMask key="autoresizingMask"/>
+                                                <subviews>
+                                                    <textField verticalHuggingPriority="750" id="70">
+                                                        <rect key="frame" x="199" y="193" width="230" height="19"/>
+                                                        <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
+                                                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" alignment="left" drawsBackground="YES" id="562">
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                            <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                    <textField verticalHuggingPriority="750" id="203">
+                                                        <rect key="frame" x="20" y="195" width="174" height="14"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="right" title="Nick completion suffix:" id="566">
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                    <button id="92">
+                                                        <rect key="frame" x="29" y="215" width="200" height="19"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <buttonCell key="cell" type="check" title="Nick Completion" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" inset="2" id="563">
+                                                            <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                        </buttonCell>
+                                                    </button>
+                                                    <button id="220">
+                                                        <rect key="frame" x="29" y="305" width="411" height="19"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <buttonCell key="cell" type="check" title="Interpret %nnn as an ASCII value" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" inset="2" id="567">
+                                                            <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                        </buttonCell>
+                                                    </button>
+                                                    <button id="9">
+                                                        <rect key="frame" x="29" y="345" width="411" height="19"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <buttonCell key="cell" type="check" title="Use the Text box font and colors" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" inset="2" id="560">
+                                                            <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                        </buttonCell>
+                                                    </button>
+                                                    <button id="155">
+                                                        <rect key="frame" x="29" y="325" width="164" height="19"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <buttonCell key="cell" type="check" title="Spell checking" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" inset="2" id="565">
+                                                            <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                        </buttonCell>
+                                                    </button>
+                                                    <button id="978">
+                                                        <rect key="frame" x="196" y="325" width="120" height="19"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <buttonCell key="cell" type="check" title="Grammar" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" inset="2" id="979">
+                                                            <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                        </buttonCell>
+                                                    </button>
+                                                    <button id="980">
+                                                        <rect key="frame" x="319" y="325" width="121" height="19"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <buttonCell key="cell" type="check" title="Autocorrection" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" inset="2" id="981">
+                                                            <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                        </buttonCell>
+                                                    </button>
+                                                    <button id="14">
+                                                        <rect key="frame" x="29" y="285" width="411" height="19"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <buttonCell key="cell" type="check" title="Interpret %C, %B as Color, Bold etc" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" inset="2" id="561">
+                                                            <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                        </buttonCell>
+                                                    </button>
+                                                    <button id="128">
+                                                        <rect key="frame" x="231" y="215" width="200" height="19"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <buttonCell key="cell" type="check" title="Suffix style nick completion" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" inset="2" id="564">
+                                                            <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                        </buttonCell>
+                                                    </button>
+                                                    <button id="354">
+                                                        <rect key="frame" x="29" y="146" width="411" height="19"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <buttonCell key="cell" type="check" title="Scroll tab-key completion choices" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" inset="2" id="568">
+                                                            <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                        </buttonCell>
+                                                    </button>
+                                                    <textField verticalHuggingPriority="750" id="412">
+                                                        <rect key="frame" x="20" y="170" width="174" height="17"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="right" title="Nick completion sorted:" id="569">
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                    <popUpButton verticalHuggingPriority="750" id="413">
+                                                        <rect key="frame" x="196" y="166" width="236" height="22"/>
+                                                        <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
+                                                        <popUpButtonCell key="cell" type="push" title="A-Z" bezelStyle="rounded" alignment="left" controlSize="small" lineBreakMode="clipping" state="on" borderStyle="borderAndBezel" inset="2" arrowPosition="arrowAtCenter" preferredEdge="maxY" selectedItem="415" id="570">
+                                                            <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                            <menu key="menu" id="414">
+                                                                <items>
+                                                                    <menuItem title="A-Z" state="on" id="415"/>
+                                                                    <menuItem title="Last-spoke order" tag="1" id="416"/>
+                                                                </items>
+                                                            </menu>
+                                                        </popUpButtonCell>
+                                                    </popUpButton>
+                                                    <textField verticalHuggingPriority="750" id="628">
+                                                        <rect key="frame" x="17" y="369" width="415" height="17"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Input box" id="629">
+                                                            <font key="font" metaFont="systemBold"/>
+                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                    <textField verticalHuggingPriority="750" id="630">
+                                                        <rect key="frame" x="17" y="239" width="415" height="17"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Nick Completion" id="631">
+                                                            <font key="font" metaFont="systemBold"/>
+                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                </subviews>
+                                            </view>
+                                        </tabViewItem>
+                                        <tabViewItem identifier="" id="168" userLabel="User list">
+                                            <view key="view" id="60">
+                                                <rect key="frame" x="0.0" y="0.0" width="449" height="406"/>
+                                                <autoresizingMask key="autoresizingMask"/>
+                                                <subviews>
+                                                    <textField verticalHuggingPriority="750" id="127">
+                                                        <rect key="frame" x="229" y="137" width="200" height="19"/>
+                                                        <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
+                                                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" alignment="left" drawsBackground="YES" id="555">
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                            <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                    <textField verticalHuggingPriority="750" id="802">
+                                                        <rect key="frame" x="229" y="186" width="60" height="19"/>
+                                                        <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
+                                                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" alignment="left" drawsBackground="YES" id="803">
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                            <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                    <textField verticalHuggingPriority="750" id="225">
+                                                        <rect key="frame" x="17" y="136" width="207" height="17"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="right" title="Execute command:" id="559">
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                    <textField verticalHuggingPriority="750" id="129">
+                                                        <rect key="frame" x="29" y="258" width="195" height="17"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="right" title="User list sorted by:" id="556">
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                    <textField verticalHuggingPriority="750" id="800">
+                                                        <rect key="frame" x="-3" y="188" width="227" height="14"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="right" title="On channels smaller than:" id="801">
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                    <popUpButton verticalHuggingPriority="750" id="215">
+                                                        <rect key="frame" x="226" y="254" width="206" height="22"/>
+                                                        <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
+                                                        <popUpButtonCell key="cell" type="push" title="A-Z, Ops first" bezelStyle="rounded" alignment="left" controlSize="small" lineBreakMode="clipping" state="on" borderStyle="borderAndBezel" inset="2" arrowPosition="arrowAtCenter" preferredEdge="maxY" selectedItem="200" id="558">
+                                                            <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                            <menu key="menu" id="216">
+                                                                <items>
+                                                                    <menuItem title="A-Z, Ops first" state="on" id="200"/>
+                                                                    <menuItem title="A-Z" id="8"/>
+                                                                    <menuItem title="Z-A, Ops last" id="219"/>
+                                                                    <menuItem title="Z-A" id="68"/>
+                                                                    <menuItem title="Unsorted" id="79"/>
+                                                                </items>
+                                                            </menu>
+                                                        </popUpButtonCell>
+                                                    </popUpButton>
+                                                    <button id="102">
+                                                        <rect key="frame" x="29" y="281" width="394" height="19"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <buttonCell key="cell" type="check" title="Userlist buttons enabled" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" inset="2" id="554">
+                                                            <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                        </buttonCell>
+                                                    </button>
+                                                    <button id="161">
+                                                        <rect key="frame" x="29" y="302" width="394" height="19"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <buttonCell key="cell" type="check" title="Hide user list" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" inset="2" id="557">
+                                                            <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                        </buttonCell>
+                                                    </button>
+                                                    <button id="910">
+                                                        <rect key="frame" x="29" y="323" width="411" height="19"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <buttonCell key="cell" type="check" title="Use the Text box font and colors" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" inset="2" id="911">
+                                                            <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                        </buttonCell>
+                                                    </button>
+                                                    <button id="798">
+                                                        <rect key="frame" x="29" y="208" width="394" height="19"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <buttonCell key="cell" type="check" title="Track the Away status of users and mark them in a different color" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" inset="2" id="799">
+                                                            <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                        </buttonCell>
+                                                    </button>
+                                                    <button id="13">
+                                                        <rect key="frame" x="29" y="344" width="394" height="19"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <buttonCell key="cell" type="check" title="Show hostnames in user list" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" inset="2" id="553">
+                                                            <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                        </buttonCell>
+                                                    </button>
+                                                    <textField verticalHuggingPriority="750" id="632">
+                                                        <rect key="frame" x="17" y="369" width="242" height="17"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="User List" id="633">
+                                                            <font key="font" metaFont="systemBold"/>
+                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                    <textField verticalHuggingPriority="750" id="634">
+                                                        <rect key="frame" x="17" y="161" width="342" height="17"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Action Upon Double Click" id="635">
+                                                            <font key="font" metaFont="systemBold"/>
+                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                    <textField verticalHuggingPriority="750" id="796">
+                                                        <rect key="frame" x="17" y="233" width="342" height="17"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Away tracking" id="797">
+                                                            <font key="font" metaFont="systemBold"/>
+                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                </subviews>
+                                            </view>
+                                        </tabViewItem>
+                                        <tabViewItem identifier="" id="50" userLabel="Channel switcher">
+                                            <view key="view" id="77">
+                                                <rect key="frame" x="0.0" y="0.0" width="449" height="406"/>
+                                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                <subviews>
+                                                    <textField verticalHuggingPriority="750" id="36">
+                                                        <rect key="frame" x="22" y="119" width="144" height="17"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="right" title="Open channels in:" id="478">
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                    <popUpButton verticalHuggingPriority="750" id="113">
+                                                        <rect key="frame" x="168" y="116" width="106" height="22"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <popUpButtonCell key="cell" type="push" title="Tabs" bezelStyle="rounded" alignment="left" controlSize="small" lineBreakMode="clipping" state="on" borderStyle="borderAndBezel" inset="2" arrowPosition="arrowAtCenter" preferredEdge="maxY" selectedItem="10" id="483">
+                                                            <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                            <menu key="menu" id="149">
+                                                                <items>
+                                                                    <menuItem title="Windows" id="140"/>
+                                                                    <menuItem title="Tabs" state="on" id="10"/>
+                                                                </items>
+                                                            </menu>
+                                                        </popUpButtonCell>
+                                                    </popUpButton>
+                                                    <textField verticalHuggingPriority="750" id="97">
+                                                        <rect key="frame" x="22" y="94" width="144" height="17"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="right" title="Open dialogs in:" id="482">
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                    <popUpButton verticalHuggingPriority="750" id="93">
+                                                        <rect key="frame" x="168" y="91" width="106" height="22"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <popUpButtonCell key="cell" type="push" title="Tabs" bezelStyle="rounded" alignment="left" controlSize="small" lineBreakMode="clipping" state="on" borderStyle="borderAndBezel" inset="2" arrowPosition="arrowAtCenter" preferredEdge="maxY" selectedItem="124" id="481">
+                                                            <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                            <menu key="menu" id="78">
+                                                                <items>
+                                                                    <menuItem title="Windows" id="148"/>
+                                                                    <menuItem title="Tabs" state="on" id="124"/>
+                                                                </items>
+                                                            </menu>
+                                                        </popUpButtonCell>
+                                                    </popUpButton>
+                                                    <textField verticalHuggingPriority="750" id="54">
+                                                        <rect key="frame" x="22" y="69" width="144" height="17"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="right" title="Open utilities in:" id="479">
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                    <popUpButton verticalHuggingPriority="750" id="134">
+                                                        <rect key="frame" x="168" y="66" width="106" height="22"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <popUpButtonCell key="cell" type="push" title="Tabs" bezelStyle="rounded" alignment="left" controlSize="small" lineBreakMode="clipping" state="on" borderStyle="borderAndBezel" inset="2" arrowPosition="arrowAtCenter" preferredEdge="maxY" selectedItem="174" id="484">
+                                                            <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                            <menu key="menu" id="30">
+                                                                <items>
+                                                                    <menuItem title="Windows" id="132"/>
+                                                                    <menuItem title="Tabs" state="on" id="174"/>
+                                                                </items>
+                                                            </menu>
+                                                        </popUpButtonCell>
+                                                    </popUpButton>
+                                                    <popUpButton verticalHuggingPriority="750" id="5">
+                                                        <rect key="frame" x="168" y="206" width="106" height="22"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <popUpButtonCell key="cell" type="push" title="Bottom" bezelStyle="rounded" alignment="left" controlSize="small" lineBreakMode="clipping" state="on" borderStyle="borderAndBezel" inset="2" arrowPosition="arrowAtCenter" preferredEdge="maxY" selectedItem="179" id="476">
+                                                            <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                            <menu key="menu" id="82">
+                                                                <items>
+                                                                    <menuItem title="Bottom" state="on" id="179"/>
+                                                                    <menuItem title="Top" id="182"/>
+                                                                    <menuItem title="Right" id="143"/>
+                                                                    <menuItem title="Left" id="130"/>
+                                                                </items>
+                                                            </menu>
+                                                        </popUpButtonCell>
+                                                    </popUpButton>
+                                                    <popUpButton verticalHuggingPriority="750" id="875">
+                                                        <rect key="frame" x="168" y="364" width="106" height="22"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <popUpButtonCell key="cell" type="push" title="Tabs" bezelStyle="rounded" alignment="left" controlSize="small" lineBreakMode="clipping" state="on" borderStyle="borderAndBezel" inset="2" arrowPosition="arrowAtCenter" preferredEdge="maxY" selectedItem="879" id="876">
+                                                            <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                            <menu key="menu" id="877">
+                                                                <items>
+                                                                    <menuItem title="Tabs" state="on" id="879"/>
+                                                                    <menuItem title="Tree" id="878"/>
+                                                                </items>
+                                                            </menu>
+                                                        </popUpButtonCell>
+                                                    </popUpButton>
+                                                    <button id="118">
+                                                        <rect key="frame" x="29" y="302" width="382" height="19"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <buttonCell key="cell" type="check" title="Open a new tab when you receive a private message" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" inset="2" id="430">
+                                                            <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                        </buttonCell>
+                                                    </button>
+                                                    <textField verticalHuggingPriority="750" id="209">
+                                                        <rect key="frame" x="4" y="210" width="162" height="14"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="right" title="Show channel switcher at:" id="486">
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                    <textField verticalHuggingPriority="750" id="860">
+                                                        <rect key="frame" x="4" y="366" width="162" height="17"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="right" title="Switcher type:" id="861">
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                    <textField verticalHuggingPriority="750" id="806">
+                                                        <rect key="frame" x="4" y="184" width="162" height="17"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="right" title="Shorten tab labels to:" id="807">
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                    <button id="86">
+                                                        <rect key="frame" x="29" y="344" width="382" height="19"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <buttonCell key="cell" type="check" title="Open an extra tab for server messages" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" inset="2" id="480">
+                                                            <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                        </buttonCell>
+                                                    </button>
+                                                    <button id="11">
+                                                        <rect key="frame" x="29" y="323" width="382" height="19"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <buttonCell key="cell" type="check" title="Open an extra tab for server notices" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" inset="2" id="477">
+                                                            <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                        </buttonCell>
+                                                    </button>
+                                                    <button id="214">
+                                                        <rect key="frame" x="29" y="281" width="384" height="19"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <buttonCell key="cell" type="check" title="Pop new tabs to front" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" inset="2" id="487">
+                                                            <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                        </buttonCell>
+                                                    </button>
+                                                    <button id="204">
+                                                        <rect key="frame" x="29" y="260" width="382" height="19"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <buttonCell key="cell" type="check" title="Hide &quot;close&quot; buttons on tabs" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" inset="2" id="485">
+                                                            <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                        </buttonCell>
+                                                    </button>
+                                                    <button id="898">
+                                                        <rect key="frame" x="29" y="239" width="382" height="19"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <buttonCell key="cell" type="check" title="Smaller text" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" inset="2" id="899">
+                                                            <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                        </buttonCell>
+                                                    </button>
+                                                    <textField verticalHuggingPriority="750" id="636">
+                                                        <rect key="frame" x="22" y="149" width="410" height="17"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Tabs or Windows" id="637">
+                                                            <font key="font" metaFont="systemBold"/>
+                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                    <textField verticalHuggingPriority="750" id="808">
+                                                        <rect key="frame" x="171" y="183" width="100" height="19"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="809">
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                            <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                    <button hidden="YES" id="921">
+                                                        <rect key="frame" x="29" y="291" width="394" height="19"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <buttonCell key="cell" type="check" title="Sort tabs in alphabetical order" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" enabled="NO" inset="2" id="922">
+                                                            <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                        </buttonCell>
+                                                    </button>
+                                                </subviews>
+                                            </view>
+                                        </tabViewItem>
+                                        <tabViewItem identifier="" id="26" userLabel="Other">
+                                            <view key="view" id="35">
+                                                <rect key="frame" x="0.0" y="0.0" width="449" height="406"/>
+                                                <autoresizingMask key="autoresizingMask"/>
+                                                <subviews>
+                                                    <button id="91">
+                                                        <rect key="frame" x="19" y="357" width="412" height="19"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <buttonCell key="cell" type="check" title="Show channel mode buttons" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" inset="2" id="446">
+                                                            <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                        </buttonCell>
+                                                    </button>
+                                                    <textField verticalHuggingPriority="750" id="356">
+                                                        <rect key="frame" x="17" y="317" width="123" height="16"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="right" title="Default character set:" id="447">
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                    <textField verticalHuggingPriority="750" id="357">
+                                                        <rect key="frame" x="145" y="315" width="101" height="19"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" alignment="left" drawsBackground="YES" id="448">
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                            <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                    <box verticalHuggingPriority="750" title="Box" boxType="separator" titlePosition="noTitle" id="358">
+                                                        <rect key="frame" x="12" y="340" width="425" height="5"/>
+                                                        <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
+                                                        <color key="borderColor" white="0.0" alpha="0.41999999999999998" colorSpace="calibratedWhite"/>
+                                                        <color key="fillColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
+                                                        <font key="titleFont" metaFont="system"/>
+                                                    </box>
+                                                    <textField verticalHuggingPriority="750" id="791">
+                                                        <rect key="frame" x="251" y="318" width="232" height="14"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="(Change takes effect at next launch)" id="792">
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                    <textField verticalHuggingPriority="750" id="89">
+                                                        <rect key="frame" x="209" y="255" width="220" height="19"/>
+                                                        <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
+                                                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" alignment="left" drawsBackground="YES" id="503">
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                            <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                    <textField verticalHuggingPriority="750" id="222">
+                                                        <rect key="frame" x="29" y="257" width="175" height="14"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="right" title="URL link command:" id="517">
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                    <textField verticalHuggingPriority="750" id="156">
+                                                        <rect key="frame" x="209" y="226" width="220" height="19"/>
+                                                        <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
+                                                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" alignment="left" drawsBackground="YES" id="509">
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                            <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                    <textField verticalHuggingPriority="750" id="112">
+                                                        <rect key="frame" x="31" y="228" width="175" height="14"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="right" title="Nick link command:" id="505">
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                    <textField verticalHuggingPriority="750" id="62">
+                                                        <rect key="frame" x="209" y="197" width="220" height="19"/>
+                                                        <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
+                                                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" alignment="left" drawsBackground="YES" id="499">
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                            <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                    <textField verticalHuggingPriority="750" id="210">
+                                                        <rect key="frame" x="19" y="199" width="185" height="14"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="right" title="Channel link command:" id="515">
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                    <textField verticalHuggingPriority="750" id="626">
+                                                        <rect key="frame" x="17" y="279" width="415" height="17"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Command" id="627">
+                                                            <font key="font" metaFont="systemBold"/>
+                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                </subviews>
+                                            </view>
+                                        </tabViewItem>
+                                        <tabViewItem identifier="" id="38" userLabel="Colors">
+                                            <view key="view" id="33">
+                                                <rect key="frame" x="0.0" y="0.0" width="449" height="406"/>
+                                                <autoresizingMask key="autoresizingMask"/>
+                                                <subviews>
+                                                    <textField verticalHuggingPriority="750" id="594">
+                                                        <rect key="frame" x="14" y="368" width="205" height="18"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="left" title="Text Colors" id="595">
+                                                            <font key="font" metaFont="systemBold" size="12"/>
+                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                    <textField verticalHuggingPriority="750" id="170">
+                                                        <rect key="frame" x="106" y="347" width="20" height="13"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="center" title="0" id="472">
+                                                            <font key="font" metaFont="label"/>
+                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                    <textField verticalHuggingPriority="750" id="23">
+                                                        <rect key="frame" x="127" y="347" width="20" height="13"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="center" title="1" id="453">
+                                                            <font key="font" metaFont="label"/>
+                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                    <textField verticalHuggingPriority="750" id="159">
+                                                        <rect key="frame" x="148" y="347" width="20" height="13"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="center" title="2" id="469">
+                                                            <font key="font" metaFont="label"/>
+                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                    <textField verticalHuggingPriority="750" id="90">
+                                                        <rect key="frame" x="169" y="347" width="20" height="13"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="center" title="3" id="461">
+                                                            <font key="font" metaFont="label"/>
+                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                    <textField verticalHuggingPriority="750" id="29">
+                                                        <rect key="frame" x="190" y="347" width="20" height="13"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="center" title="4" id="456">
+                                                            <font key="font" metaFont="label"/>
+                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                    <textField verticalHuggingPriority="750" id="7">
+                                                        <rect key="frame" x="211" y="347" width="20" height="13"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="center" title="5" id="450">
+                                                            <font key="font" metaFont="label"/>
+                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                    <textField verticalHuggingPriority="750" id="66">
+                                                        <rect key="frame" x="232" y="347" width="20" height="13"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="center" title="6" id="458">
+                                                            <font key="font" metaFont="label"/>
+                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                    <textField verticalHuggingPriority="750" id="25">
+                                                        <rect key="frame" x="253" y="347" width="20" height="13"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="center" title="7" id="454">
+                                                            <font key="font" metaFont="label"/>
+                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                    <textField verticalHuggingPriority="750" id="183">
+                                                        <rect key="frame" x="274" y="347" width="20" height="13"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="center" title="8" id="473">
+                                                            <font key="font" metaFont="label"/>
+                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                    <textField verticalHuggingPriority="750" id="94">
+                                                        <rect key="frame" x="295" y="347" width="20" height="13"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="center" title="9" id="462">
+                                                            <font key="font" metaFont="label"/>
+                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                    <textField verticalHuggingPriority="750" id="100">
+                                                        <rect key="frame" x="315" y="347" width="22" height="13"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="center" title="10" id="463">
+                                                            <font key="font" metaFont="label"/>
+                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                    <textField verticalHuggingPriority="750" id="160">
+                                                        <rect key="frame" x="336" y="347" width="22" height="13"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="center" title="11" id="470">
+                                                            <font key="font" metaFont="label"/>
+                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                    <textField verticalHuggingPriority="750" id="122">
+                                                        <rect key="frame" x="357" y="347" width="22" height="13"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="center" title="12" id="466">
+                                                            <font key="font" metaFont="label"/>
+                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                    <textField verticalHuggingPriority="750" id="109">
+                                                        <rect key="frame" x="378" y="347" width="22" height="13"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="center" title="13" id="465">
+                                                            <font key="font" metaFont="label"/>
+                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                    <textField verticalHuggingPriority="750" id="142">
+                                                        <rect key="frame" x="399" y="347" width="22" height="13"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="center" title="14" id="468">
+                                                            <font key="font" metaFont="label"/>
+                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                    <textField verticalHuggingPriority="750" id="15">
+                                                        <rect key="frame" x="420" y="347" width="22" height="13"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="center" title="15" id="451">
+                                                            <font key="font" metaFont="label"/>
+                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                    <textField verticalHuggingPriority="750" id="212">
+                                                        <rect key="frame" x="14" y="327" width="89" height="17"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="right" title="mIRC colors:" id="474">
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                    <colorWell id="191">
+                                                        <rect key="frame" x="106" y="327" width="20" height="20"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <color key="color" red="0.05813049898" green="0.055541899059999997" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                                    </colorWell>
+                                                    <colorWell tag="1" id="153">
+                                                        <rect key="frame" x="127" y="327" width="20" height="20"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <color key="color" red="0.05813049898" green="0.055541899059999997" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                                    </colorWell>
+                                                    <colorWell tag="2" id="151">
+                                                        <rect key="frame" x="148" y="327" width="20" height="20"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <color key="color" red="0.05813049898" green="0.055541899059999997" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                                    </colorWell>
+                                                    <colorWell tag="3" id="121">
+                                                        <rect key="frame" x="169" y="327" width="20" height="20"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <color key="color" red="0.05813049898" green="0.055541899059999997" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                                    </colorWell>
+                                                    <colorWell tag="4" id="120">
+                                                        <rect key="frame" x="190" y="327" width="20" height="20"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <color key="color" red="0.05813049898" green="0.055541899059999997" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                                    </colorWell>
+                                                    <colorWell tag="5" id="96">
+                                                        <rect key="frame" x="211" y="327" width="20" height="20"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <color key="color" red="0.05813049898" green="0.055541899059999997" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                                    </colorWell>
+                                                    <colorWell tag="6" id="224">
+                                                        <rect key="frame" x="232" y="327" width="20" height="20"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <color key="color" red="0.05813049898" green="0.055541899059999997" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                                    </colorWell>
+                                                    <colorWell tag="7" id="42">
+                                                        <rect key="frame" x="253" y="327" width="20" height="20"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <color key="color" red="0.05813049898" green="0.055541899059999997" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                                    </colorWell>
+                                                    <colorWell tag="8" id="188">
+                                                        <rect key="frame" x="274" y="327" width="20" height="20"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <color key="color" red="0.05813049898" green="0.055541899059999997" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                                    </colorWell>
+                                                    <colorWell tag="9" id="12">
+                                                        <rect key="frame" x="295" y="327" width="20" height="20"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <color key="color" red="0.05813049898" green="0.055541899059999997" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                                    </colorWell>
+                                                    <colorWell tag="10" id="193">
+                                                        <rect key="frame" x="316" y="327" width="20" height="20"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <color key="color" red="0.05813049898" green="0.055541899059999997" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                                    </colorWell>
+                                                    <colorWell tag="11" id="39">
+                                                        <rect key="frame" x="337" y="327" width="20" height="20"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <color key="color" red="0.05813049898" green="0.055541899059999997" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                                    </colorWell>
+                                                    <colorWell tag="12" id="199">
+                                                        <rect key="frame" x="358" y="327" width="20" height="20"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <color key="color" red="0.05813049898" green="0.055541899059999997" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                                    </colorWell>
+                                                    <colorWell tag="13" id="37">
+                                                        <rect key="frame" x="379" y="327" width="20" height="20"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <color key="color" red="0.05813049898" green="0.055541899059999997" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                                    </colorWell>
+                                                    <colorWell tag="14" id="61">
+                                                        <rect key="frame" x="400" y="327" width="20" height="20"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <color key="color" red="0.05813049898" green="0.055541899059999997" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                                    </colorWell>
+                                                    <colorWell tag="15" id="196">
+                                                        <rect key="frame" x="421" y="327" width="20" height="20"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <color key="color" red="0.05813049898" green="0.055541899059999997" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                                    </colorWell>
+                                                    <textField verticalHuggingPriority="750" id="344">
+                                                        <rect key="frame" x="14" y="303" width="89" height="17"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="right" title="Local colors:" id="475">
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                    <colorWell tag="16" id="347">
+                                                        <rect key="frame" x="106" y="301" width="20" height="20"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <color key="color" red="0.05813049898" green="0.055541899059999997" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                                    </colorWell>
+                                                    <colorWell tag="17" id="345">
+                                                        <rect key="frame" x="127" y="301" width="20" height="20"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <color key="color" red="0.05813049898" green="0.055541899059999997" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                                    </colorWell>
+                                                    <colorWell tag="18" id="343">
+                                                        <rect key="frame" x="148" y="301" width="20" height="20"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <color key="color" red="0.05813049898" green="0.055541899059999997" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                                    </colorWell>
+                                                    <colorWell tag="19" id="337">
+                                                        <rect key="frame" x="169" y="301" width="20" height="20"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <color key="color" red="0.05813049898" green="0.055541899059999997" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                                    </colorWell>
+                                                    <colorWell tag="20" id="339">
+                                                        <rect key="frame" x="190" y="301" width="20" height="20"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <color key="color" red="0.05813049898" green="0.055541899059999997" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                                    </colorWell>
+                                                    <colorWell tag="21" id="340">
+                                                        <rect key="frame" x="211" y="301" width="20" height="20"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <color key="color" red="0.05813049898" green="0.055541899059999997" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                                    </colorWell>
+                                                    <colorWell tag="22" id="351">
+                                                        <rect key="frame" x="232" y="301" width="20" height="20"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <color key="color" red="0.05813049898" green="0.055541899059999997" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                                    </colorWell>
+                                                    <colorWell tag="23" id="348">
+                                                        <rect key="frame" x="253" y="301" width="20" height="20"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <color key="color" red="0.05813049898" green="0.055541899059999997" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                                    </colorWell>
+                                                    <colorWell tag="24" id="341">
+                                                        <rect key="frame" x="274" y="301" width="20" height="20"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <color key="color" red="0.05813049898" green="0.055541899059999997" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                                    </colorWell>
+                                                    <colorWell tag="25" id="350">
+                                                        <rect key="frame" x="295" y="301" width="20" height="20"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <color key="color" red="0.05813049898" green="0.055541899059999997" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                                    </colorWell>
+                                                    <colorWell tag="26" id="352">
+                                                        <rect key="frame" x="316" y="301" width="20" height="20"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <color key="color" red="0.05813049898" green="0.055541899059999997" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                                    </colorWell>
+                                                    <colorWell tag="27" id="342">
+                                                        <rect key="frame" x="337" y="301" width="20" height="20"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <color key="color" red="0.05813049898" green="0.055541899059999997" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                                    </colorWell>
+                                                    <colorWell tag="28" id="349">
+                                                        <rect key="frame" x="358" y="301" width="20" height="20"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <color key="color" red="0.05813049898" green="0.055541899059999997" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                                    </colorWell>
+                                                    <colorWell tag="29" id="346">
+                                                        <rect key="frame" x="379" y="301" width="20" height="20"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <color key="color" red="0.05813049898" green="0.055541899059999997" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                                    </colorWell>
+                                                    <colorWell tag="30" id="338">
+                                                        <rect key="frame" x="400" y="301" width="20" height="20"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <color key="color" red="0.05813049898" green="0.055541899059999997" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                                    </colorWell>
+                                                    <colorWell tag="31" id="353">
+                                                        <rect key="frame" x="421" y="301" width="20" height="20"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <color key="color" red="0.05813049898" green="0.055541899059999997" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                                    </colorWell>
+                                                    <textField verticalHuggingPriority="750" id="88">
+                                                        <rect key="frame" x="14" y="275" width="87" height="17"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="right" title="Foreground:" id="460">
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                    <colorWell tag="34" id="59">
+                                                        <rect key="frame" x="106" y="275" width="20" height="20"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <color key="color" red="0.05813049898" green="0.055541899059999997" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                                    </colorWell>
+                                                    <textField verticalHuggingPriority="750" id="34">
+                                                        <rect key="frame" x="166" y="275" width="124" height="17"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="right" title="Background:" id="457">
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                    <colorWell tag="35" id="157">
+                                                        <rect key="frame" x="295" y="275" width="20" height="20"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <color key="color" red="0.05813049898" green="0.055541899059999997" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                                    </colorWell>
+                                                    <textField verticalHuggingPriority="750" id="596">
+                                                        <rect key="frame" x="14" y="241" width="205" height="20"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="left" title="Marking Text" id="597">
+                                                            <font key="font" metaFont="systemBold" size="12"/>
+                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                    <textField verticalHuggingPriority="750" id="20">
+                                                        <rect key="frame" x="14" y="213" width="87" height="17"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="right" title="Foreground:" id="452">
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                    <colorWell tag="32" id="186">
+                                                        <rect key="frame" x="106" y="213" width="20" height="20"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <color key="color" red="0.05813049898" green="0.055541899059999997" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                                    </colorWell>
+                                                    <textField verticalHuggingPriority="750" id="139">
+                                                        <rect key="frame" x="166" y="213" width="124" height="17"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="right" title="Background:" id="467">
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                    <colorWell tag="33" id="6">
+                                                        <rect key="frame" x="295" y="213" width="20" height="20"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <color key="color" red="0.05813049898" green="0.055541899059999997" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                                    </colorWell>
+                                                    <textField verticalHuggingPriority="750" id="598">
+                                                        <rect key="frame" x="14" y="178" width="205" height="21"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="left" title="Interface Colors" id="599">
+                                                            <font key="font" metaFont="systemBold" size="12"/>
+                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                    <textField verticalHuggingPriority="750" id="69">
+                                                        <rect key="frame" x="14" y="153" width="87" height="17"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="right" title="New data:" id="459">
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                    <colorWell tag="37" id="146">
+                                                        <rect key="frame" x="106" y="153" width="20" height="20"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <color key="color" red="0.05813049898" green="0.055541899059999997" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                                    </colorWell>
+                                                    <textField verticalHuggingPriority="750" id="27">
+                                                        <rect key="frame" x="166" y="153" width="124" height="17"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="right" title="Highlight:" id="455">
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                    <colorWell tag="38" id="115">
+                                                        <rect key="frame" x="295" y="153" width="20" height="20"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <color key="color" red="0.05813049898" green="0.055541899059999997" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                                    </colorWell>
+                                                    <textField verticalHuggingPriority="750" id="108">
+                                                        <rect key="frame" x="14" y="128" width="87" height="17"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="right" title="New message:" id="464">
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                    <colorWell tag="39" id="221">
+                                                        <rect key="frame" x="106" y="128" width="20" height="20"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <color key="color" red="0.05813049898" green="0.055541899059999997" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                                    </colorWell>
+                                                    <textField verticalHuggingPriority="750" id="164">
+                                                        <rect key="frame" x="166" y="128" width="124" height="17"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="right" title="Away user:" id="471">
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                    <colorWell tag="40" id="166">
+                                                        <rect key="frame" x="295" y="128" width="20" height="20"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <color key="color" red="0.05813049898" green="0.055541899059999997" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                                    </colorWell>
+                                                    <button verticalHuggingPriority="750" id="913">
+                                                        <rect key="frame" x="11" y="12" width="210" height="32"/>
+                                                        <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                        <buttonCell key="cell" type="push" title="Load Default Colors" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="914">
+                                                            <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                                            <font key="font" metaFont="system"/>
+                                                        </buttonCell>
+                                                        <connections>
+                                                            <action selector="loadColorFromDefault:" target="111" id="917"/>
+                                                        </connections>
+                                                    </button>
+                                                    <button verticalHuggingPriority="750" id="915">
+                                                        <rect key="frame" x="225" y="12" width="210" height="32"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMinX="YES" widthSizable="YES" flexibleMaxY="YES"/>
+                                                        <buttonCell key="cell" type="push" title="Load From File..." bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="916">
+                                                            <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                                            <font key="font" metaFont="system"/>
+                                                        </buttonCell>
+                                                        <connections>
+                                                            <action selector="loadColorFromFile:" target="111" id="918"/>
+                                                        </connections>
+                                                    </button>
+                                                </subviews>
+                                            </view>
+                                        </tabViewItem>
+                                        <tabViewItem identifier="" id="709" userLabel="Alerts">
+                                            <view key="view" id="710">
+                                                <rect key="frame" x="0.0" y="0.0" width="449" height="406"/>
+                                                <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                                <subviews>
+                                                    <button id="119">
+                                                        <rect key="frame" x="29" y="344" width="237" height="19"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <buttonCell key="cell" type="check" title="Beep on private messages" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" inset="2" id="431">
+                                                            <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                        </buttonCell>
+                                                    </button>
+                                                    <button id="152">
+                                                        <rect key="frame" x="29" y="323" width="237" height="19"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <buttonCell key="cell" type="check" title="Beep on channel messages" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" inset="2" id="433">
+                                                            <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                        </buttonCell>
+                                                    </button>
+                                                    <button id="821">
+                                                        <rect key="frame" x="29" y="302" width="237" height="19"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <buttonCell key="cell" type="check" title="Beep on highlighted messages" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" inset="2" id="822">
+                                                            <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                        </buttonCell>
+                                                    </button>
+                                                    <textField verticalHuggingPriority="750" id="154">
+                                                        <rect key="frame" x="219" y="213" width="210" height="19"/>
+                                                        <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
+                                                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" alignment="left" drawsBackground="YES" id="434">
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                            <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                    <textField verticalHuggingPriority="750" id="67">
+                                                        <rect key="frame" x="6" y="212" width="208" height="17"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="right" title="Extra words to highlight:" id="425">
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                    <textField verticalHuggingPriority="750" id="811">
+                                                        <rect key="frame" x="219" y="186" width="210" height="19"/>
+                                                        <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
+                                                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" alignment="left" drawsBackground="YES" id="814">
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                            <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                    <textField verticalHuggingPriority="750" id="812">
+                                                        <rect key="frame" x="6" y="185" width="208" height="17"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="right" title="Nick names not to highlight:" id="813">
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                    <textField verticalHuggingPriority="750" id="815">
+                                                        <rect key="frame" x="219" y="159" width="210" height="19"/>
+                                                        <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
+                                                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" alignment="left" drawsBackground="YES" id="818">
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                            <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                    <textField verticalHuggingPriority="750" id="816">
+                                                        <rect key="frame" x="6" y="161" width="208" height="14"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="right" title="Nick names to always highlight:" id="817">
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                    <textField verticalHuggingPriority="750" id="711">
+                                                        <rect key="frame" x="17" y="262" width="153" height="17"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Highlighted Messages" id="712">
+                                                            <font key="font" metaFont="systemBold"/>
+                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                    <textField verticalHuggingPriority="750" id="718">
+                                                        <rect key="frame" x="17" y="369" width="153" height="17"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Alerts" id="719">
+                                                            <font key="font" metaFont="systemBold"/>
+                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                    <textField verticalHuggingPriority="750" id="713">
+                                                        <rect key="frame" x="29" y="240" width="415" height="14"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Highlighted messages are ones where your nickname is mentioned, but also:" id="714">
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                    <textField verticalHuggingPriority="750" id="826">
+                                                        <rect key="frame" x="166" y="123" width="266" height="28"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMinY="YES"/>
+                                                        <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Separate multiple words with commas. Wildcards are accepted." id="827">
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                </subviews>
+                                            </view>
+                                        </tabViewItem>
+                                        <tabViewItem identifier="" id="19" userLabel="General">
+                                            <view key="view" id="123">
+                                                <rect key="frame" x="0.0" y="0.0" width="449" height="406"/>
+                                                <autoresizingMask key="autoresizingMask"/>
+                                                <subviews>
+                                                    <textField verticalHuggingPriority="750" id="40">
+                                                        <rect key="frame" x="128" y="342" width="301" height="19"/>
+                                                        <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
+                                                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" alignment="left" drawsBackground="YES" id="423">
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                            <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                    <textField verticalHuggingPriority="750" id="95">
+                                                        <rect key="frame" x="17" y="341" width="106" height="17"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="right" title="Quit:" id="427">
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                    <textField verticalHuggingPriority="750" id="592">
+                                                        <rect key="frame" x="17" y="369" width="415" height="17"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <textFieldCell key="cell" allowsUndo="NO" sendsActionOnEndEditing="YES" title="Default Messages" id="593">
+                                                            <font key="font" metaFont="systemBold"/>
+                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                    <textField verticalHuggingPriority="750" id="716">
+                                                        <rect key="frame" x="17" y="234" width="415" height="17"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <textFieldCell key="cell" allowsUndo="NO" sendsActionOnEndEditing="YES" title="Away" id="717">
+                                                            <font key="font" metaFont="systemBold"/>
+                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                    <textField verticalHuggingPriority="750" id="110">
+                                                        <rect key="frame" x="128" y="314" width="301" height="19"/>
+                                                        <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
+                                                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" alignment="left" drawsBackground="YES" id="428">
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                            <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                    <textField verticalHuggingPriority="750" id="202">
+                                                        <rect key="frame" x="17" y="313" width="106" height="17"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="right" title="Leave channel:" id="439">
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                    <textField verticalHuggingPriority="750" id="125">
+                                                        <rect key="frame" x="128" y="287" width="301" height="19"/>
+                                                        <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
+                                                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" alignment="left" drawsBackground="YES" id="432">
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                            <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                    <textField verticalHuggingPriority="750" id="165">
+                                                        <rect key="frame" x="17" y="286" width="106" height="17"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="right" title="Away:" id="436">
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                    <button id="114">
+                                                        <rect key="frame" x="29" y="209" width="267" height="19"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <buttonCell key="cell" type="check" title="Announce away messages" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" inset="2" id="429">
+                                                            <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                        </buttonCell>
+                                                    </button>
+                                                    <button id="162">
+                                                        <rect key="frame" x="29" y="188" width="267" height="19"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <buttonCell key="cell" type="check" title="Show away once" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" inset="2" id="435">
+                                                            <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                        </buttonCell>
+                                                    </button>
+                                                    <button id="17">
+                                                        <rect key="frame" x="29" y="167" width="267" height="19"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <buttonCell key="cell" type="check" title="Automatically unmark away" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" inset="2" id="422">
+                                                            <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                        </buttonCell>
+                                                    </button>
+                                                    <textField verticalHuggingPriority="750" id="322">
+                                                        <rect key="frame" x="17" y="259" width="106" height="17"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="right" title="Sleep:" id="440">
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                    <textField verticalHuggingPriority="750" id="323">
+                                                        <rect key="frame" x="128" y="260" width="301" height="19"/>
+                                                        <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
+                                                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" alignment="left" drawsBackground="YES" id="441">
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                            <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                    <button id="377">
+                                                        <rect key="frame" x="29" y="146" width="267" height="19"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <buttonCell key="cell" type="check" title="/part channels on sleep" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" inset="2" id="442">
+                                                            <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                        </buttonCell>
+                                                    </button>
+                                                    <button id="407">
+                                                        <rect key="frame" x="29" y="125" width="182" height="19"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <buttonCell key="cell" type="check" title="Auto-away after" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" inset="2" id="443">
+                                                            <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                        </buttonCell>
+                                                    </button>
+                                                    <textField verticalHuggingPriority="750" id="408">
+                                                        <rect key="frame" x="209" y="125" width="29" height="19"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" alignment="left" drawsBackground="YES" id="444">
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                            <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                    <textField verticalHuggingPriority="750" id="409">
+                                                        <rect key="frame" x="243" y="125" width="83" height="17"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="left" title="minutes" id="445">
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                </subviews>
+                                            </view>
+                                        </tabViewItem>
+                                        <tabViewItem identifier="" id="64" userLabel="Logging">
+                                            <view key="view" id="76">
+                                                <rect key="frame" x="0.0" y="0.0" width="449" height="406"/>
+                                                <autoresizingMask key="autoresizingMask"/>
+                                                <subviews>
+                                                    <textField verticalHuggingPriority="750" id="201">
+                                                        <rect key="frame" x="19" y="304" width="153" height="14"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="right" title="Log filename:" id="495">
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                    <textField verticalHuggingPriority="750" id="150">
+                                                        <rect key="frame" x="177" y="217" width="252" height="19"/>
+                                                        <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
+                                                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" alignment="left" drawsBackground="YES" id="492">
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                            <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                    <textField verticalHuggingPriority="750" id="177">
+                                                        <rect key="frame" x="17" y="220" width="155" height="14"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="right" title="Log timestamp format:" id="494">
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                    <textField verticalHuggingPriority="750" id="217">
+                                                        <rect key="frame" x="177" y="301" width="252" height="19"/>
+                                                        <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
+                                                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" alignment="left" drawsBackground="YES" id="496">
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                            <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                    <button id="158">
+                                                        <rect key="frame" x="29" y="238" width="404" height="19"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <buttonCell key="cell" type="check" title="Insert timestamps in logs" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" inset="2" id="493">
+                                                            <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                        </buttonCell>
+                                                    </button>
+                                                    <button id="46">
+                                                        <rect key="frame" x="29" y="324" width="402" height="19"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <buttonCell key="cell" type="check" title="Enable logging of conversations to disk" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" inset="2" id="491">
+                                                            <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                        </buttonCell>
+                                                    </button>
+                                                    <button id="830">
+                                                        <rect key="frame" x="29" y="344" width="400" height="19"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <buttonCell key="cell" type="check" title="Display scrollback from previous session" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" inset="2" id="831">
+                                                            <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                        </buttonCell>
+                                                    </button>
+                                                    <textField verticalHuggingPriority="750" id="638">
+                                                        <rect key="frame" x="17" y="369" width="415" height="17"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Logging" id="639">
+                                                            <font key="font" metaFont="system"/>
+                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                    <textField verticalHuggingPriority="750" id="640">
+                                                        <rect key="frame" x="19" y="262" width="415" height="17"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Time Stamps" id="641">
+                                                            <font key="font" metaFont="system"/>
+                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                    <textField verticalHuggingPriority="750" id="642">
+                                                        <rect key="frame" x="192" y="287" width="242" height="11"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <textFieldCell key="cell" controlSize="mini" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="%s=Server %c=Channel %n=Network." id="643">
+                                                            <font key="font" metaFont="miniSystem"/>
+                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                    <textField verticalHuggingPriority="750" id="644">
+                                                        <rect key="frame" x="192" y="204" width="240" height="11"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <textFieldCell key="cell" controlSize="mini" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="See strftime manpage for details." id="645">
+                                                            <font key="font" metaFont="miniSystem"/>
+                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                </subviews>
+                                            </view>
+                                        </tabViewItem>
+                                        <tabViewItem identifier="" id="313" userLabel="Sound">
+                                            <view key="view" id="314">
+                                                <rect key="frame" x="0.0" y="0.0" width="449" height="406"/>
+                                                <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                                <subviews>
+                                                    <scrollView horizontalLineScroll="19" horizontalPageScroll="10" verticalLineScroll="19" verticalPageScroll="10" usesPredominantAxisScrolling="NO" id="316">
+                                                        <rect key="frame" x="20" y="70" width="409" height="314"/>
+                                                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                                        <clipView key="contentView" id="Mu4-mm-ccb">
+                                                            <rect key="frame" x="1" y="17" width="392" height="281"/>
+                                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                                            <subviews>
+                                                                <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" alternatingRowBackgroundColors="YES" columnSelection="YES" multipleSelection="NO" autosaveColumns="NO" headerView="588" id="317">
+                                                                    <rect key="frame" x="0.0" y="0.0" width="392" height="281"/>
+                                                                    <autoresizingMask key="autoresizingMask"/>
+                                                                    <size key="intercellSpacing" width="3" height="2"/>
+                                                                    <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                                                    <color key="gridColor" name="gridColor" catalog="System" colorSpace="catalog"/>
+                                                                    <tableColumns>
+                                                                        <tableColumn width="145" minWidth="40" maxWidth="1000" id="318">
+                                                                            <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left" title="Event">
+                                                                                <font key="font" metaFont="smallSystem"/>
+                                                                                <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
+                                                                                <color key="backgroundColor" white="0.33333298560000002" alpha="1" colorSpace="calibratedWhite"/>
+                                                                            </tableHeaderCell>
+                                                                            <textFieldCell key="dataCell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" alignment="left" id="581">
+                                                                                <font key="font" metaFont="system"/>
+                                                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                                                <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                                                            </textFieldCell>
+                                                                            <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
+                                                                        </tableColumn>
+                                                                        <tableColumn width="117.26999664306641" minWidth="8" maxWidth="1000" id="315">
+                                                                            <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left" title="Sound file">
+                                                                                <font key="font" metaFont="smallSystem"/>
+                                                                                <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
+                                                                                <color key="backgroundColor" white="0.33333298560000002" alpha="1" colorSpace="calibratedWhite"/>
+                                                                            </tableHeaderCell>
+                                                                            <textFieldCell key="dataCell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" alignment="left" id="580">
+                                                                                <font key="font" metaFont="system"/>
+                                                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                                                <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                                                            </textFieldCell>
+                                                                            <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
+                                                                        </tableColumn>
+                                                                        <tableColumn width="28" minWidth="28" maxWidth="1000" id="362">
+                                                                            <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="center" title="G">
+                                                                                <font key="font" metaFont="smallSystem"/>
+                                                                                <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
+                                                                                <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
+                                                                            </tableHeaderCell>
+                                                                            <textFieldCell key="dataCell" lineBreakMode="truncatingTail" selectable="YES" editable="YES" alignment="center" id="582">
+                                                                                <font key="font" metaFont="system"/>
+                                                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                                                <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                                            </textFieldCell>
+                                                                        </tableColumn>
+                                                                        <tableColumn width="28" minWidth="28" maxWidth="1000" id="X9Q-Sr-VEq">
+                                                                            <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="center" title="N">
+                                                                                <font key="font" metaFont="smallSystem"/>
+                                                                                <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
+                                                                                <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
+                                                                            </tableHeaderCell>
+                                                                            <textFieldCell key="dataCell" lineBreakMode="truncatingTail" selectable="YES" editable="YES" alignment="center" id="SjW-F1-xvs">
+                                                                                <font key="font" metaFont="system"/>
+                                                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                                                <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                                            </textFieldCell>
+                                                                        </tableColumn>
+                                                                        <tableColumn width="28" minWidth="28" maxWidth="1000" id="363">
+                                                                            <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="center" title="B">
+                                                                                <font key="font" metaFont="smallSystem"/>
+                                                                                <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
+                                                                                <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
+                                                                            </tableHeaderCell>
+                                                                            <textFieldCell key="dataCell" lineBreakMode="truncatingTail" selectable="YES" editable="YES" alignment="center" id="583">
+                                                                                <font key="font" metaFont="system"/>
+                                                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                                                <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                                            </textFieldCell>
+                                                                        </tableColumn>
+                                                                        <tableColumn width="28" minWidth="28" maxWidth="1000" id="364">
+                                                                            <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="center" title="S">
+                                                                                <font key="font" metaFont="smallSystem"/>
+                                                                                <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
+                                                                                <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
+                                                                            </tableHeaderCell>
+                                                                            <textFieldCell key="dataCell" lineBreakMode="truncatingTail" selectable="YES" editable="YES" alignment="center" id="584">
+                                                                                <font key="font" metaFont="system"/>
+                                                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                                                <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                                            </textFieldCell>
+                                                                        </tableColumn>
+                                                                    </tableColumns>
+                                                                    <connections>
+                                                                        <outlet property="dataSource" destination="111" id="745"/>
+                                                                    </connections>
+                                                                </tableView>
+                                                            </subviews>
+                                                            <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                        </clipView>
+                                                        <scroller key="horizontalScroller" verticalHuggingPriority="750" horizontal="YES" id="587">
+                                                            <rect key="frame" x="1" y="298" width="392" height="15"/>
+                                                            <autoresizingMask key="autoresizingMask"/>
+                                                        </scroller>
+                                                        <scroller key="verticalScroller" verticalHuggingPriority="750" horizontal="NO" id="586">
+                                                            <rect key="frame" x="393" y="17" width="15" height="281"/>
+                                                            <autoresizingMask key="autoresizingMask"/>
+                                                        </scroller>
+                                                        <tableHeaderView key="headerView" id="588">
+                                                            <rect key="frame" x="0.0" y="0.0" width="392" height="17"/>
+                                                            <autoresizingMask key="autoresizingMask"/>
+                                                        </tableHeaderView>
+                                                    </scrollView>
+                                                    <textField verticalHuggingPriority="750" id="365">
+                                                        <rect key="frame" x="17" y="49" width="204" height="13"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                        <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="G = Show event with Growl" id="571">
+                                                            <font key="font" metaFont="label"/>
+                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                    <textField verticalHuggingPriority="750" id="366">
+                                                        <rect key="frame" x="17" y="7" width="204" height="13"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                        <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="B = Bounce the dock icon" id="572">
+                                                            <font key="font" metaFont="label"/>
+                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                    <textField verticalHuggingPriority="750" id="367">
+                                                        <rect key="frame" x="17" y="21" width="204" height="13"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                        <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="S = Show indicator in the dock" id="573">
+                                                            <font key="font" metaFont="label"/>
+                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                    <button id="368">
+                                                        <rect key="frame" x="215" y="48" width="216" height="19"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                        <buttonCell key="cell" type="check" title="Perform when X-Chat Aqua is not in front" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="mini" enabled="NO" state="on" inset="2" id="574">
+                                                            <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                            <font key="font" metaFont="miniSystem"/>
+                                                        </buttonCell>
+                                                    </button>
+                                                    <button id="369">
+                                                        <rect key="frame" x="215" y="33" width="216" height="19"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                        <buttonCell key="cell" type="check" title="Perform always" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="mini" enabled="NO" state="mixed" allowsMixedState="YES" inset="2" id="575">
+                                                            <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                            <font key="font" metaFont="miniSystem"/>
+                                                        </buttonCell>
+                                                    </button>
+                                                    <button id="975">
+                                                        <rect key="frame" x="216" y="11" width="215" height="19"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <buttonCell key="cell" type="check" title="Bounce Continuously" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="976">
+                                                            <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                            <font key="font" metaFont="system"/>
+                                                        </buttonCell>
+                                                    </button>
+                                                    <textField verticalHuggingPriority="750" id="2vq-mc-04g">
+                                                        <rect key="frame" x="17" y="35" width="204" height="13"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                        <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="N = Show event with Notification Center" id="XTB-Rp-2DV">
+                                                            <font key="font" metaFont="label"/>
+                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                </subviews>
+                                            </view>
+                                        </tabViewItem>
+                                        <tabViewItem identifier="" id="923" userLabel="Advanced">
+                                            <view key="view" id="924">
+                                                <rect key="frame" x="0.0" y="0.0" width="449" height="406"/>
+                                                <autoresizingMask key="autoresizingMask"/>
+                                                <subviews>
+                                                    <textField verticalHuggingPriority="750" id="951">
+                                                        <rect key="frame" x="5" y="369" width="415" height="17"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <textFieldCell key="cell" allowsUndo="NO" sendsActionOnEndEditing="YES" title="Advanced Settings" id="960">
+                                                            <font key="font" metaFont="systemBold"/>
+                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                    <button id="952">
+                                                        <rect key="frame" x="17" y="323" width="237" height="19"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <buttonCell key="cell" type="check" title="Display MODEs in raw form" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" inset="2" id="959">
+                                                            <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                        </buttonCell>
+                                                    </button>
+                                                    <button id="953">
+                                                        <rect key="frame" x="17" y="302" width="231" height="19"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <buttonCell key="cell" type="check" title="Whois on notify" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" inset="2" id="958">
+                                                            <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                        </buttonCell>
+                                                    </button>
+                                                    <button id="954">
+                                                        <rect key="frame" x="17" y="281" width="237" height="19"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <buttonCell key="cell" type="check" title="Hide join and part messages" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" inset="2" id="957">
+                                                            <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                        </buttonCell>
+                                                    </button>
+                                                    <button id="955">
+                                                        <rect key="frame" x="17" y="344" width="220" height="19"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <buttonCell key="cell" type="check" title="Automatically rejoin channel" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" inset="2" id="956">
+                                                            <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                        </buttonCell>
+                                                    </button>
+                                                    <textField verticalHuggingPriority="750" id="766">
+                                                        <rect key="frame" x="5" y="258" width="352" height="17"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Auto Open DCC Windows" id="767">
+                                                            <font key="font" metaFont="systemBold"/>
+                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                    <button id="116">
+                                                        <rect key="frame" x="17" y="212" width="294" height="19"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <buttonCell key="cell" type="check" title="Send window" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" inset="2" id="541">
+                                                            <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                        </buttonCell>
+                                                    </button>
+                                                    <button id="141">
+                                                        <rect key="frame" x="17" y="170" width="294" height="19"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <buttonCell key="cell" type="check" title="Chat window" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" inset="2" id="543">
+                                                            <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                        </buttonCell>
+                                                    </button>
+                                                    <button id="136">
+                                                        <rect key="frame" x="17" y="191" width="294" height="19"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <buttonCell key="cell" type="check" title="Receive window" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" inset="2" id="542">
+                                                            <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                        </buttonCell>
+                                                    </button>
+                                                    <popUpButton verticalHuggingPriority="750" id="184">
+                                                        <rect key="frame" x="191" y="233" width="128" height="22"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <popUpButtonCell key="cell" type="push" title="Normal" bezelStyle="rounded" alignment="left" controlSize="small" lineBreakMode="clipping" state="on" borderStyle="borderAndBezel" inset="2" arrowPosition="arrowAtCenter" preferredEdge="maxY" selectedItem="22" id="546">
+                                                            <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                            <menu key="menu" id="31">
+                                                                <items>
+                                                                    <menuItem title="Normal" state="on" id="22"/>
+                                                                    <menuItem title="Auto Accept" id="44"/>
+                                                                    <menuItem title="Ask me" id="52"/>
+                                                                </items>
+                                                            </menu>
+                                                        </popUpButtonCell>
+                                                    </popUpButton>
+                                                    <textField verticalHuggingPriority="750" id="73">
+                                                        <rect key="frame" x="12" y="235" width="177" height="17"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="right" title="DCC Chat Action" id="538">
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                </subviews>
+                                            </view>
+                                        </tabViewItem>
+                                        <tabViewItem identifier="" id="126" userLabel="Network setup">
+                                            <view key="view" id="21">
+                                                <rect key="frame" x="0.0" y="0.0" width="449" height="406"/>
+                                                <autoresizingMask key="autoresizingMask"/>
+                                                <subviews>
+                                                    <textField verticalHuggingPriority="750" id="172">
+                                                        <rect key="frame" x="141" y="345" width="288" height="19"/>
+                                                        <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
+                                                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" alignment="left" drawsBackground="YES" id="528">
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                            <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                    <textField verticalHuggingPriority="750" id="58">
+                                                        <rect key="frame" x="15" y="348" width="121" height="14"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="right" title="Bind to:" id="520">
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                    <textField verticalHuggingPriority="750" id="604">
+                                                        <rect key="frame" x="17" y="329" width="415" height="17"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" alignment="right" title="Only useful for computers with multiple addresses." id="605">
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                    <textField verticalHuggingPriority="750" id="103">
+                                                        <rect key="frame" x="17" y="292" width="119" height="17"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="right" title="Hostname:" id="523">
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                    <textField verticalHuggingPriority="750" id="600">
+                                                        <rect key="frame" x="17" y="320" width="415" height="17"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="left" title="Proxy Server" id="601">
+                                                            <font key="font" metaFont="systemBold"/>
+                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                    <textField verticalHuggingPriority="750" id="844">
+                                                        <rect key="frame" x="17" y="191" width="415" height="17"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="left" title="Proxy Authentication" id="845">
+                                                            <font key="font" metaFont="systemBold"/>
+                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                    <textField verticalHuggingPriority="750" id="748">
+                                                        <rect key="frame" x="17" y="88" width="415" height="17"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="left" title="Other" id="749">
+                                                            <font key="font" metaFont="systemBold"/>
+                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                    <textField verticalHuggingPriority="750" id="602">
+                                                        <rect key="frame" x="17" y="369" width="415" height="17"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="left" title="Your Address" id="603">
+                                                            <font key="font" metaFont="systemBold"/>
+                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                    <textField verticalHuggingPriority="750" id="85">
+                                                        <rect key="frame" x="141" y="293" width="288" height="19"/>
+                                                        <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
+                                                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" alignment="left" drawsBackground="YES" id="521">
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                            <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                    <textField verticalHuggingPriority="750" id="848">
+                                                        <rect key="frame" x="17" y="140" width="119" height="17"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="right" title="Username:" id="851">
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                    <textField verticalHuggingPriority="750" id="849">
+                                                        <rect key="frame" x="141" y="141" width="288" height="19"/>
+                                                        <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
+                                                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" alignment="left" drawsBackground="YES" id="850">
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                            <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                    <textField verticalHuggingPriority="750" id="207">
+                                                        <rect key="frame" x="17" y="265" width="119" height="17"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="right" title="Port:" id="532">
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                    <textField verticalHuggingPriority="750" id="181">
+                                                        <rect key="frame" x="17" y="240" width="119" height="17"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="right" title="Type:" id="530">
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                    <textField verticalHuggingPriority="750" id="104">
+                                                        <rect key="frame" x="141" y="266" width="48" height="19"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" alignment="left" drawsBackground="YES" id="524">
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                            <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                    <popUpButton verticalHuggingPriority="750" id="138">
+                                                        <rect key="frame" x="138" y="237" width="146" height="22"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <popUpButtonCell key="cell" type="push" title="(Disabled)" bezelStyle="rounded" alignment="left" controlSize="small" lineBreakMode="clipping" state="on" borderStyle="borderAndBezel" inset="2" arrowPosition="arrowAtCenter" preferredEdge="maxY" selectedItem="75" id="526">
+                                                            <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                            <menu key="menu" id="117">
+                                                                <items>
+                                                                    <menuItem title="(Disabled)" state="on" id="75"/>
+                                                                    <menuItem title="Wingate" id="175"/>
+                                                                    <menuItem title="Socks4" id="208"/>
+                                                                    <menuItem title="Socks5" id="32"/>
+                                                                    <menuItem title="HTTP" id="197"/>
+                                                                </items>
+                                                            </menu>
+                                                        </popUpButtonCell>
+                                                    </popUpButton>
+                                                    <textField verticalHuggingPriority="750" id="833">
+                                                        <rect key="frame" x="17" y="216" width="119" height="17"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="right" title="Use proxy for:" id="842">
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                    <popUpButton verticalHuggingPriority="750" id="834">
+                                                        <rect key="frame" x="138" y="212" width="146" height="22"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <popUpButtonCell key="cell" type="push" title="All Connections" bezelStyle="rounded" alignment="left" controlSize="small" lineBreakMode="clipping" state="on" borderStyle="borderAndBezel" inset="2" arrowPosition="arrowAtCenter" preferredEdge="maxY" selectedItem="840" id="835">
+                                                            <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                            <menu key="menu" id="836">
+                                                                <items>
+                                                                    <menuItem title="All Connections" state="on" id="840"/>
+                                                                    <menuItem title="IRC Server Only" id="839"/>
+                                                                    <menuItem title="DCC Get Only" id="837"/>
+                                                                </items>
+                                                            </menu>
+                                                        </popUpButtonCell>
+                                                    </popUpButton>
+                                                    <button id="189">
+                                                        <rect key="frame" x="27" y="19" width="402" height="19"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <buttonCell key="cell" type="check" title="Enable built-in identd (requires administrator privileges)" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" inset="2" id="531">
+                                                            <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                        </buttonCell>
+                                                    </button>
+                                                    <textField verticalHuggingPriority="750" id="16">
+                                                        <rect key="frame" x="309" y="63" width="121" height="14"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="left" title="seconds" id="519">
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                    <textField verticalHuggingPriority="750" id="171">
+                                                        <rect key="frame" x="257" y="61" width="47" height="19"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" alignment="left" drawsBackground="YES" id="527">
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                            <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                    <button id="101">
+                                                        <rect key="frame" x="27" y="61" width="224" height="19"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <buttonCell key="cell" type="check" title="Auto reconnect to server after" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" inset="2" id="522">
+                                                            <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                        </buttonCell>
+                                                    </button>
+                                                    <button id="846">
+                                                        <rect key="frame" x="29" y="166" width="299" height="19"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <buttonCell key="cell" type="check" title="Use Authentication (HTTP or Socks5 only)" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" inset="2" id="847">
+                                                            <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                        </buttonCell>
+                                                    </button>
+                                                    <button id="178">
+                                                        <rect key="frame" x="27" y="40" width="402" height="19"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <buttonCell key="cell" type="check" title="Never give up reconnect" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" inset="2" id="529">
+                                                            <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                        </buttonCell>
+                                                    </button>
+                                                    <textField verticalHuggingPriority="750" id="852">
+                                                        <rect key="frame" x="17" y="112" width="119" height="17"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="right" title="Password:" id="855">
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                    <textField verticalHuggingPriority="750" id="853">
+                                                        <rect key="frame" x="141" y="113" width="288" height="19"/>
+                                                        <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
+                                                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" alignment="left" drawsBackground="YES" id="854">
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                            <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                </subviews>
+                                            </view>
+                                        </tabViewItem>
+                                        <tabViewItem identifier="" id="135" userLabel="File transfers">
+                                            <view key="view" id="144">
+                                                <rect key="frame" x="0.0" y="0.0" width="449" height="406"/>
+                                                <autoresizingMask key="autoresizingMask"/>
+                                                <subviews>
+                                                    <textField verticalHuggingPriority="750" id="47">
+                                                        <rect key="frame" x="17" y="192" width="177" height="17"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="right" title="First DCC send port:" id="534">
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                    <textField verticalHuggingPriority="750" id="71">
+                                                        <rect key="frame" x="199" y="220" width="230" height="19"/>
+                                                        <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
+                                                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" alignment="left" drawsBackground="YES" id="537">
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                            <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                    <textField verticalHuggingPriority="750" id="99">
+                                                        <rect key="frame" x="199" y="192" width="44" height="19"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" alignment="left" title="0" drawsBackground="YES" id="540">
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                            <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                    <textField verticalHuggingPriority="750" id="211">
+                                                        <rect key="frame" x="17" y="222" width="177" height="14"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="right" title="DCC IP address:" id="549">
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                    <textField hidden="YES" verticalHuggingPriority="750" id="195">
+                                                        <rect key="frame" x="199" y="318" width="230" height="19"/>
+                                                        <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
+                                                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" alignment="left" drawsBackground="YES" id="547">
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                            <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                    <textField hidden="YES" verticalHuggingPriority="750" id="28">
+                                                        <rect key="frame" x="5" y="320" width="189" height="14"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="right" title="Download files to:" id="533">
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                    <textField verticalHuggingPriority="750" id="51">
+                                                        <rect key="frame" x="17" y="168" width="177" height="14"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="right" title="Last DCC send port:" id="535">
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                    <textField verticalHuggingPriority="750" id="98">
+                                                        <rect key="frame" x="199" y="165" width="44" height="19"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" alignment="left" title="0" drawsBackground="YES" id="539">
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                            <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                    <button id="147">
+                                                        <rect key="frame" x="29" y="292" width="195" height="19"/>
+                                                        <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <buttonCell key="cell" type="check" title="Save nick name in filenames" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" inset="2" id="544">
+                                                            <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                        </buttonCell>
+                                                    </button>
+                                                    <button id="63">
+                                                        <rect key="frame" x="236" y="292" width="195" height="19"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMinX="YES" widthSizable="YES" flexibleMinY="YES"/>
+                                                        <buttonCell key="cell" type="check" title="Convert spaces to underscore" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" inset="2" id="536">
+                                                            <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                        </buttonCell>
+                                                    </button>
+                                                    <button id="223">
+                                                        <rect key="frame" x="29" y="245" width="222" height="19"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <buttonCell key="cell" type="check" title="Get my address from the IRC server" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" inset="2" id="550">
+                                                            <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                        </buttonCell>
+                                                    </button>
+                                                    <textField verticalHuggingPriority="750" id="176">
+                                                        <rect key="frame" x="5" y="342" width="189" height="17"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="right" title="Auto accept file offers:" id="545">
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                    <popUpButton verticalHuggingPriority="750" id="206">
+                                                        <rect key="frame" x="196" y="340" width="128" height="22"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <popUpButtonCell key="cell" type="push" title="Ask me" bezelStyle="rounded" alignment="left" controlSize="small" lineBreakMode="clipping" state="on" borderStyle="borderAndBezel" inset="2" arrowPosition="arrowAtCenter" preferredEdge="maxY" selectedItem="192" id="548">
+                                                            <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                            <menu key="menu" id="45">
+                                                                <items>
+                                                                    <menuItem title="No" id="43"/>
+                                                                    <menuItem title="Yes" id="173"/>
+                                                                    <menuItem title="Ask me" state="on" id="192"/>
+                                                                </items>
+                                                            </menu>
+                                                        </popUpButtonCell>
+                                                    </popUpButton>
+                                                    <textField verticalHuggingPriority="750" id="371">
+                                                        <rect key="frame" x="199" y="317" width="230" height="19"/>
+                                                        <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
+                                                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" alignment="left" drawsBackground="YES" id="551">
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                            <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                    <textField verticalHuggingPriority="750" id="372">
+                                                        <rect key="frame" x="-3" y="317" width="197" height="19"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="right" title="Move completed files to:" id="552">
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                    <textField verticalHuggingPriority="750" id="646">
+                                                        <rect key="frame" x="17" y="369" width="323" height="17"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Files and Directories" id="647">
+                                                            <font key="font" metaFont="systemBold"/>
+                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                    <textField verticalHuggingPriority="750" id="648">
+                                                        <rect key="frame" x="17" y="269" width="352" height="17"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Network Settings" id="649">
+                                                            <font key="font" metaFont="systemBold"/>
+                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                    <textField verticalHuggingPriority="750" id="650">
+                                                        <rect key="frame" x="243" y="169" width="209" height="11"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <textFieldCell key="cell" controlSize="mini" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="!Leave ports at zero for full range." id="651">
+                                                            <font key="font" metaFont="miniSystem"/>
+                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                </subviews>
+                                            </view>
+                                        </tabViewItem>
+                                    </tabViewItems>
+                                </tabView>
+                            </subviews>
+                        </view>
+                        <color key="borderColor" white="0.0" alpha="0.41999999999999998" colorSpace="calibratedWhite"/>
+                        <color key="fillColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
+                        <font key="titleFont" metaFont="system"/>
+                    </box>
+                    <button hidden="YES" verticalHuggingPriority="750" id="80">
+                        <rect key="frame" x="14" y="12" width="150" height="32"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                        <buttonCell key="cell" type="push" title="Show Prefs Files" bezelStyle="rounded" alignment="center" borderStyle="border" inset="2" id="577">
+                            <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                            <font key="font" metaFont="system"/>
+                        </buttonCell>
+                        <connections>
+                            <action selector="showRawPreferences:" target="111" id="782"/>
+                        </connections>
+                    </button>
+                </subviews>
+            </view>
+            <connections>
+                <outlet property="autoAcceptDccChatPopUp" destination="184" id="777"/>
+                <outlet property="autoAcceptDccPopUp" destination="206" id="772"/>
+                <outlet property="autoAwayCheckBox" destination="407" id="728"/>
+                <outlet property="autoAwayMinutesTextField" destination="408" id="729"/>
+                <outlet property="autoDialogCheckBox" destination="118" id="733"/>
+                <outlet property="autoOpenDccChatCheckBox" destination="141" id="774"/>
+                <outlet property="autoOpenDccReceiveCheckBox" destination="136" id="775"/>
+                <outlet property="autoOpenDccSendCheckBox" destination="116" id="776"/>
+                <outlet property="autoReconnectCheckBox" destination="101" id="755"/>
+                <outlet property="autoReconnectDelayTextField" destination="171" id="756"/>
+                <outlet property="autoRejoinCheckBox" destination="955" id="961"/>
+                <outlet property="autoUnmarkAwayCheckBox" destination="17" id="732"/>
+                <outlet property="autocorrectionCheckBox" destination="980" id="983"/>
+                <outlet property="awayMaxSizeTextField" destination="802" id="804"/>
+                <outlet property="awayMessageTextField" destination="125" id="724"/>
+                <outlet property="awayTrackCheckBox" destination="798" id="805"/>
+                <outlet property="backgroundImageTextField" destination="883" id="890"/>
+                <outlet property="beepOnChannelCheckBox" destination="152" id="722"/>
+                <outlet property="beepOnHighlightedCheckBox" destination="821" id="823"/>
+                <outlet property="beepOnPrivateCheckBox" destination="119" id="723"/>
+                <outlet property="bindAddressTextField" destination="172" id="750"/>
+                <outlet property="bounceCountinuouslyCheckBox" destination="975" id="977"/>
+                <outlet property="categoryOutlineView" destination="24" id="705"/>
+                <outlet property="channelLinkCommandTextField" destination="62" id="676"/>
+                <outlet property="coloredNicksCheckBox" destination="137" id="666"/>
+                <outlet property="colorsTabViewItem" destination="38" id="793"/>
+                <outlet property="completedDownloadsDirectoryTextField" destination="371" id="763"/>
+                <outlet property="contentBox" destination="48" id="773"/>
+                <outlet property="dccAddressTextField" destination="71" id="769"/>
+                <outlet property="dccFirstSendPortTextField" destination="99" id="770"/>
+                <outlet property="dccLastSendPortTextField" destination="98" id="771"/>
+                <outlet property="defaultCharsetTextField" destination="357" id="704"/>
+                <outlet property="displayPreviousScrollbackCheckBox" destination="830" id="832"/>
+                <outlet property="doubleClickCommandTextField" destination="127" id="691"/>
+                <outlet property="downloadSpaceToUnderscoreCheckBox" destination="63" id="761"/>
+                <outlet property="downloadWithNickCheckBox" destination="147" id="762"/>
+                <outlet property="downloadsDirectoryTextField" destination="195" id="760"/>
+                <outlet property="enableLoggingCheckBox" destination="46" id="740"/>
+                <outlet property="extraHighlightWordsTextField" destination="154" id="715"/>
+                <outlet property="grammerCheckingCheckBox" destination="978" id="982"/>
+                <outlet property="hideJoinPartCheckBox" destination="954" id="962"/>
+                <outlet property="hideTabCloseButtonsCheckBox" destination="204" id="695"/>
+                <outlet property="hideUserlistCheckBox" destination="161" id="688"/>
+                <outlet property="identdCheckBox" destination="189" id="757"/>
+                <outlet property="indentNicksCheckBox" destination="167" id="779"/>
+                <outlet property="inputBoxUseTextBoxFontCheckBox" destination="9" id="678"/>
+                <outlet property="interpretPercentAsciiCheckBox" destination="220" id="680"/>
+                <outlet property="interpretPercentColorCheckBox" destination="14" id="681"/>
+                <outlet property="ipFromServerCheckBox" destination="223" id="768"/>
+                <outlet property="lineHeightTextField" destination="970" id="974"/>
+                <outlet property="logFilenameMaskTextField" destination="217" id="741"/>
+                <outlet property="maxLinesTextField" destination="205" id="665"/>
+                <outlet property="neverGiveUpReconnectionCheckBox" destination="178" id="758"/>
+                <outlet property="newTabsToFrontCheckBox" destination="214" id="692"/>
+                <outlet property="nickCompletionSortPopUp" destination="413" id="685"/>
+                <outlet property="nickHighlightWordsTextField" destination="815" id="820"/>
+                <outlet property="nickLinkCommandTextField" destination="156" id="677"/>
+                <outlet property="noHighlightWordsTextField" destination="811" id="819"/>
+                <outlet property="openChannelsInPopUp" destination="113" id="700"/>
+                <outlet property="openDialogsInPopUp" destination="93" id="701"/>
+                <outlet property="openUtilitiesInPopUp" destination="134" id="702"/>
+                <outlet property="partMessageTextField" destination="110" id="725"/>
+                <outlet property="partOnSleepCheckBox" destination="377" id="754"/>
+                <outlet property="proxyAuthenicationCheckBox" destination="846" id="856"/>
+                <outlet property="proxyHostTextField" destination="85" id="751"/>
+                <outlet property="proxyPasswordTextField" destination="853" id="857"/>
+                <outlet property="proxyPortTextField" destination="104" id="752"/>
+                <outlet property="proxyTypePopUp" destination="138" id="753"/>
+                <outlet property="proxyUsePopup" destination="834" id="843"/>
+                <outlet property="proxyUsernameTextField" destination="849" id="858"/>
+                <outlet property="quitMessageTextField" destination="40" id="727"/>
+                <outlet property="rawModesCheckBox" destination="952" id="963"/>
+                <outlet property="scrollbackStripColorCheckBox" destination="965" id="967"/>
+                <outlet property="scrollingCompletionCheckBox" destination="354" id="686"/>
+                <outlet property="shortenTabLabelLengthTextField" destination="808" id="810"/>
+                <outlet property="showAwayMessageCheckBox" destination="114" id="730"/>
+                <outlet property="showAwayOnceCheckBox" destination="162" id="731"/>
+                <outlet property="showChannelModeButtonsCheckBox" destination="91" id="703"/>
+                <outlet property="showHostnameCheckBox" destination="13" id="687"/>
+                <outlet property="showSeparatorCheckBox" destination="163" id="668"/>
+                <outlet property="showUserlistButtonsCheckBox" destination="102" id="690"/>
+                <outlet property="sleepMessageTextField" destination="323" id="726"/>
+                <outlet property="smallerTextTabCheckBox" destination="898" id="900"/>
+                <outlet property="soundsTableView" destination="317" id="747"/>
+                <outlet property="spellCheckingCheckBox" destination="155" id="679"/>
+                <outlet property="stripMircColorCheckBox" destination="74" id="669"/>
+                <outlet property="suffixCompletionCheckBox" destination="128" id="682"/>
+                <outlet property="suffixCompletionTextField" destination="70" id="683"/>
+                <outlet property="switcherTypePopUp" destination="875" id="882"/>
+                <outlet property="tabCompletionCheckBox" destination="92" id="684"/>
+                <outlet property="tabPositionPopUp" destination="5" id="697"/>
+                <outlet property="tabView" destination="65" id="699"/>
+                <outlet property="textBoxFontTextField" destination="145" id="664"/>
+                <outlet property="timeStampCheckBox" destination="83" id="673"/>
+                <outlet property="timeStampFormatTextField" destination="105" id="674"/>
+                <outlet property="timestampInLogsFormatTextField" destination="150" id="743"/>
+                <outlet property="timestampsInLogsCheckBox" destination="158" id="742"/>
+                <outlet property="transparentCheckBox" destination="57" id="671"/>
+                <outlet property="transparentSlider" destination="194" id="672"/>
+                <outlet property="urlLinkCommandTextField" destination="89" id="675"/>
+                <outlet property="useNoticesTabCheckBox" destination="11" id="694"/>
+                <outlet property="useServerTabCheckBox" destination="86" id="693"/>
+                <outlet property="userlistSortPopUp" destination="215" id="689"/>
+                <outlet property="userlistUseTextBoxFontCheckBox" destination="910" id="912"/>
+                <outlet property="whoisOnNotifyCheckBox" destination="953" id="964"/>
+            </connections>
+        </window>
+    </objects>
+    <resources>
+        <image name="NSStopProgressTemplate" width="11" height="11"/>
+    </resources>
+</document>

--- a/Mac/Sources/AquaChat.h
+++ b/Mac/Sources/AquaChat.h
@@ -49,7 +49,7 @@
 @class DCCChatController;
 @class XATabWindow;
 
-@interface AquaChat : NSObject <GrowlApplicationBridgeDelegate, NSApplicationDelegate, XAEventChain> {
+@interface AquaChat : NSObject <GrowlApplicationBridgeDelegate, NSApplicationDelegate, XAEventChain, NSUserNotificationCenterDelegate> {
 @public
     NSString *searchString;
     

--- a/Mac/Sources/PreferencesWindow.m
+++ b/Mac/Sources/PreferencesWindow.m
@@ -72,6 +72,7 @@ extern struct XATextEventItem XATextEvents[];
     NSString *name;
     NSNumber *sound;
     NSNumber *growl;
+    NSNumber *notification;
     NSNumber *show;
     NSNumber *bounce;
 }
@@ -99,6 +100,7 @@ extern struct XATextEventItem XATextEvents[];
         
         self->sound = [[NSNumber alloc] initWithInteger:soundIndex];
         self->growl = [[NSNumber alloc] initWithInteger:info->growl];
+        self->notification = [[NSNumber alloc] initWithInteger:info->notification];
         self->show  = [[NSNumber alloc] initWithInteger:info->show];
         self->bounce= [[NSNumber alloc] initWithInteger:info->bounce];
     }
@@ -110,6 +112,7 @@ extern struct XATextEventItem XATextEvents[];
     [name release];
     [sound release];
     [growl release];
+    [notification release];
     [bounce release];
     [show release];
     [super dealloc];
@@ -343,12 +346,13 @@ extern struct XATextEventItem XATextEvents[];
     [bcell setAllowsMixedState:YES];
     [[soundsTableView tableColumns][2] setDataCell:bcell];
     [[soundsTableView tableColumns][3] setDataCell:bcell];
+    [[soundsTableView tableColumns][4] setDataCell:bcell];
     [bcell release];
     
     bcell = [[SoundButtonCell alloc] initTextCell:@""];
     [bcell setButtonType:NSSwitchButton];
     [bcell setControlSize:NSMiniControlSize];
-    [[soundsTableView tableColumns][4] setDataCell:bcell];
+    [[soundsTableView tableColumns][5] setDataCell:bcell];
     [bcell release];
     
     [self center];
@@ -535,8 +539,9 @@ extern struct XATextEventItem XATextEvents[];
         case 0: return item->name;
         case 1: return item->sound;
         case 2: return item->growl;
-        case 3: return item->bounce;
-        case 4: return item->show;
+        case 3: return item->notification;
+        case 4: return item->bounce;
+        case 5: return item->show;
     }
     dassert(NO);
     return @"";
@@ -579,12 +584,18 @@ extern struct XATextEventItem XATextEvents[];
             break;
             
         case 3:
+            [item->notification release];
+            item->notification = [object retain];
+            XATextEvents[row].notification = [item->notification intValue];
+            break;
+            
+        case 4:
             [item->bounce release];
             item->bounce = [object retain];
             XATextEvents[row].bounce = [item->bounce intValue];
             break;
             
-        case 4:
+        case 5:
             [item->show release];
             item->show = [object retain];
             XATextEvents[row].show = [item->show intValue];

--- a/Mac/Sources/fe-aqua_common.h
+++ b/Mac/Sources/fe-aqua_common.h
@@ -34,6 +34,7 @@ struct server_gui
 
 struct XATextEventItem {
     NSInteger growl;
+    NSInteger notification;
     NSInteger show;
     NSInteger bounce;
 };

--- a/tools/localization/strings/en/xib.strings
+++ b/tools/localization/strings/en/xib.strings
@@ -140,6 +140,7 @@
       "minutes" = "minutes";
     /* Events/Sounds */
       "G = Show event with Growl" = "G = Show event with Growl";
+      "N = Show event with Notification Center" = "N = Show event with Notification Centre";
       "B = Bounce the dock icon" = "B = Bounce the dock icon";
       "S = Show indicator in the dock" = "S = Show indicator in the dock";
       "Perform when X-Chat Aqua is not in front" = "Perform when X-Chat Aqua is not in front";


### PR DESCRIPTION
As with growl the user can select in the options whether to send events to the notification center and control whether that happens if the app is in the foreground or always.

With this patch if the user has chosen to only display notifications when in the background and the app is in the foreground the event will not show a popup bubble but will still appear in the notification center history. That can be changed easily.

This code isn't ready to be merged yet, it probably needs to detect if OSX is new enough to use the notification center and my XCode also rewrote the xib file which I need to figure out how to fix but I wanted to get some feedback on whether this is something worth proceeding with.
