### PR TITLE
Fixes #129: Only use notification center if it is available.

### DIFF
--- a/Mac/Sources/AquaChat.m
+++ b/Mac/Sources/AquaChat.m
@@ -240,7 +240,7 @@ AquaChat *AquaChatSharedObject;
         }
     }
     
-    if (info->notification)
+    if (info->notification && (NSClassFromString(@"NSUserNotificationCenter") != nil))
     {
         char o[4096];
         format_event (sess, event, args, o, sizeof (o), 1);

--- a/Mac/Sources/PreferencesWindow.m
+++ b/Mac/Sources/PreferencesWindow.m
@@ -345,8 +345,16 @@ extern struct XATextEventItem XATextEvents[];
     [bcell setControlSize:NSMiniControlSize];
     [bcell setAllowsMixedState:YES];
     [[soundsTableView tableColumns][2] setDataCell:bcell];
-    [[soundsTableView tableColumns][3] setDataCell:bcell];
     [[soundsTableView tableColumns][4] setDataCell:bcell];
+    [bcell release];
+    
+    bcell = [[SoundButtonCell alloc] initTextCell:@""];
+    [bcell setButtonType:NSSwitchButton];
+    [bcell setControlSize:NSMiniControlSize];
+    [bcell setAllowsMixedState:YES];
+    if (NSClassFromString(@"NSUserNotificationCenter") == nil)
+        [bcell setEnabled:NO];
+    [[soundsTableView tableColumns][3] setDataCell:bcell];
     [bcell release];
     
     bcell = [[SoundButtonCell alloc] initTextCell:@""];


### PR DESCRIPTION
This tests whether notification center is there before trying to call it. I don't have on older OSX so I can't really test this but I think this is right.

I also made the options in preferences disabled if notification center isn't present.
