### PR TITLE
Fix link to home page in Help menu

### DIFF
--- a/Mac/Sources/AquaChat.m
+++ b/Mac/Sources/AquaChat.m
@@ -1050,7 +1050,7 @@ AquaChat *AquaChatSharedObject;
 // Open developer page
 - (void) openHomepage:(id)sender
 {
-    [[NSWorkspace sharedWorkspace] openURL:[NSURL URLWithString:@"http://xchataqua.github.com/"]];
+    [[NSWorkspace sharedWorkspace] openURL:[NSURL URLWithString:@"http://xchataqua.github.io/"]];
 }
 
 // Open the X-Chat Aqua download page (same as homepage for now).


### PR DESCRIPTION
The Help menu links to http://xchataqua.github.com/ which doesn't exist. This simply changes it to point to http://xchataqua.github.io/
This addresses Issue #279 